### PR TITLE
feat: add enforce-naming-conventions rule (config-driven)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,16 @@ export default defineConfig([
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 
-| Name                                                                   | Description                                                             | 🔧 | 💡 |
-| :--------------------------------------------------------------------- | :---------------------------------------------------------------------- | :- | :- |
-| [enforce-domain-terms](docs/rules/enforce-domain-terms.md)             | Encourage domain-specific naming using declared project terms           |    | 💡 |
-| [no-equivalent-branches](docs/rules/no-equivalent-branches.md)         | Detect if/else branches that do the same thing                          | 🔧 |    |
-| [no-generic-names](docs/rules/no-generic-names.md)                     | Flag generic names; enforce domain-specific naming                      |    |    |
-| [no-redundant-calculations](docs/rules/no-redundant-calculations.md)   | Detect redundant calculations that should be computed at compile time   | 🔧 | 💡 |
-| [no-redundant-conditionals](docs/rules/no-redundant-conditionals.md)   | Simplify redundant conditional expressions                              | 🔧 |    |
-| [no-unnecessary-abstraction](docs/rules/no-unnecessary-abstraction.md) | Suggest inlining trivial single-use wrapper functions that add no value |    | 💡 |
-| [prefer-simpler-logic](docs/rules/prefer-simpler-logic.md)             | Simplify boolean expressions and remove redundant logic                 | 🔧 |    |
+| Name                                                                   | Description                                                                                        | 🔧 | 💡 |
+| :--------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------- | :- | :- |
+| [enforce-domain-terms](docs/rules/enforce-domain-terms.md)             | Encourage domain-specific naming using declared project terms                                      |    | 💡 |
+| [enforce-naming-conventions](docs/rules/enforce-naming-conventions.md) | Enforce naming conventions from project config (style, boolean/async prefixes, plural collections) |    | 💡 |
+| [no-equivalent-branches](docs/rules/no-equivalent-branches.md)         | Detect if/else branches that do the same thing                                                     | 🔧 |    |
+| [no-generic-names](docs/rules/no-generic-names.md)                     | Flag generic names; enforce domain-specific naming                                                 |    |    |
+| [no-redundant-calculations](docs/rules/no-redundant-calculations.md)   | Detect redundant calculations that should be computed at compile time                              | 🔧 | 💡 |
+| [no-redundant-conditionals](docs/rules/no-redundant-conditionals.md)   | Simplify redundant conditional expressions                                                         | 🔧 |    |
+| [no-unnecessary-abstraction](docs/rules/no-unnecessary-abstraction.md) | Suggest inlining trivial single-use wrapper functions that add no value                            |    | 💡 |
+| [prefer-simpler-logic](docs/rules/prefer-simpler-logic.md)             | Simplify boolean expressions and remove redundant logic                                            | 🔧 |    |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/enforce-naming-conventions.md
+++ b/docs/rules/enforce-naming-conventions.md
@@ -1,0 +1,40 @@
+# Enforce naming conventions from project config (style, boolean/async prefixes, plural collections) (`ai-code-snifftest/enforce-naming-conventions`)
+
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
+<!-- end auto-generated rule header -->
+
+Enforces naming conventions configured in your `.ai-coding-guide.json` (or rule options):
+- naming.style (camelCase, snake_case, PascalCase)
+- booleanPrefix (e.g., is/has)
+- asyncPrefix (e.g., fetch/load)
+- pluralizeCollections (arrays, Set/Map)
+
+Provides suggestions to align names; fixes are applied only at the declaration site.
+
+## Options
+
+- `style`: 'camelCase' | 'snake_case' | 'PascalCase'
+- `booleanPrefix`: string[]
+- `asyncPrefix`: string[]
+- `pluralizeCollections`: boolean
+- `exemptNames`: string[]
+- `maxSuggestions`: number (default 1)
+
+## Examples
+
+### ❌ Incorrect
+```js
+const user_profile = 1;
+const active = true;
+async function user(){}
+const user = [];
+```
+
+### ✅ Correct
+```js
+const userProfile = 1;
+const isActive = true;
+async function fetchUser(){}
+const users = [];
+```

--- a/lib/rules/enforce-naming-conventions.js
+++ b/lib/rules/enforce-naming-conventions.js
@@ -1,0 +1,199 @@
+/**
+ * @fileoverview Enforce naming conventions from project config (style, boolean/async prefixes, plural collections)
+ */
+"use strict";
+
+/* eslint-disable eslint-plugin/require-meta-has-suggestions */
+
+const { readProjectConfig } = require('../utils/project-config');
+
+function isCamelCase(name) { return /^[a-z][a-zA-Z0-9]*$/.test(name); }
+function isSnakeCase(name) { return /^[a-z][a-z0-9_]*$/.test(name) && !/[A-Z]/.test(name); }
+function isPascalCase(name) { return /^[A-Z][a-zA-Z0-9]*$/.test(name); }
+
+function words(name) {
+  return String(name || '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w.toLowerCase());
+}
+
+function toCamelCase(name) {
+  const ws = words(name);
+  if (!ws.length) return name;
+  return ws[0] + ws.slice(1).map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join('');
+}
+
+function toSnakeCase(name) {
+  return words(name).join('_');
+}
+
+function toPascalCase(name) {
+  return words(name).map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join('');
+}
+
+function enforceStyle(name, style) {
+  switch (style) {
+    case 'camelCase': return isCamelCase(name) ? null : toCamelCase(name);
+    case 'snake_case': return isSnakeCase(name) ? null : toSnakeCase(name);
+    case 'PascalCase': return isPascalCase(name) ? null : toPascalCase(name);
+    default: return null;
+  }
+}
+
+function ensureBooleanPrefix(name, prefixes) {
+  if (!prefixes || !prefixes.length) return null;
+  for (const p of prefixes) {
+    if (name.startsWith(p)) return null;
+  }
+  const base = toPascalCase(name);
+  return `${prefixes[0]}${base}`;
+}
+
+function ensureAsyncPrefix(name, prefixes) {
+  if (!prefixes || !prefixes.length) return null;
+  for (const p of prefixes) {
+    if (name.startsWith(p)) return null;
+  }
+  const base = toPascalCase(name);
+  return `${prefixes[0]}${base}`;
+}
+
+function isCollectionInit(init) {
+  if (!init) return false;
+  if (init.type === 'ArrayExpression') return true;
+  if (init.type === 'NewExpression' && init.callee && init.callee.type === 'Identifier') {
+    const n = init.callee.name;
+    return n === 'Set' || n === 'Map' || n === 'WeakSet' || n === 'WeakMap';
+  }
+  return false;
+}
+
+function pluralize(name) {
+  if (/s$/.test(name)) return name; // naive OK
+  if (/y$/.test(name)) return name.replace(/y$/, 'ies');
+  return `${name}s`;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Enforce naming conventions from project config (style, boolean/async prefixes, plural collections)',
+      recommended: false,
+      url: null,
+    },
+    hasSuggestions: true,
+    fixable: null,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          style: { enum: ['camelCase','snake_case','PascalCase'] },
+          booleanPrefix: { type: 'array', items: { type: 'string' } },
+          asyncPrefix: { type: 'array', items: { type: 'string' } },
+          pluralizeCollections: { type: 'boolean' },
+          exemptNames: { type: 'array', items: { type: 'string' } },
+          maxSuggestions: { type: 'number' }
+        },
+        additionalProperties: false,
+      }
+    ],
+    messages: {
+      wrongStyle: 'Identifier "{{name}}" should follow {{style}} style',
+      booleanPrefix: 'Boolean identifier "{{name}}" should start with one of: {{prefixes}}',
+      asyncPrefix: 'Async function "{{name}}" should start with one of: {{prefixes}}',
+      pluralCollection: 'Collection "{{name}}" should be pluralized',
+      suggestRename: 'Rename to: {{suggestion}}'
+    },
+  },
+
+  create(context) {
+    const project = readProjectConfig(context) || {};
+    const cfg = project.naming || {};
+    const opt = (context.options && context.options[0]) || {};
+    const style = opt.style || cfg.style || 'camelCase';
+    const booleanPrefixes = opt.booleanPrefix || cfg.booleanPrefix || [];
+    const asyncPrefixes = opt.asyncPrefix || cfg.asyncPrefix || [];
+    const pluralizeFlag = typeof opt.pluralizeCollections === 'boolean' ? opt.pluralizeCollections : (cfg.pluralizeCollections !== false);
+    const exemptions = new Set([...(opt.exemptNames || []), ...((cfg.exemptNames)||[])]);
+    const maxSuggestions = typeof opt.maxSuggestions === 'number' ? Math.max(1, Math.min(5, opt.maxSuggestions)) : 1;
+
+    function suggest(node, messageId, data, suggestionText) {
+      const rep = { node, messageId, data };
+      if (suggestionText) {
+        rep.suggest = [
+          {
+            messageId: 'suggestRename',
+            data: { suggestion: suggestionText },
+            fix(fixer) { return fixer.replaceText(node, suggestionText); }
+          }
+        ];
+      }
+      context.report(rep);
+    }
+
+    function checkStyle(idNode) {
+      const name = idNode.name;
+      if (exemptions.has(name)) return;
+      const sugg = enforceStyle(name, style);
+      if (sugg && maxSuggestions > 0) {
+        suggest(idNode, 'wrongStyle', { name, style }, sugg);
+      }
+    }
+
+    function checkBooleanPrefix(idNode, init) {
+      if (!booleanPrefixes.length) return;
+      const name = idNode.name;
+      if (exemptions.has(name)) return;
+      if (!init || init.type !== 'Literal' || typeof init.value !== 'boolean') return;
+      const sugg = ensureBooleanPrefix(name, booleanPrefixes);
+      if (sugg) {
+        suggest(idNode, 'booleanPrefix', { name, prefixes: booleanPrefixes.join(', ') }, sugg);
+      }
+    }
+
+    function checkAsyncFunction(idNode, funcNode) {
+      if (!asyncPrefixes.length) return;
+      if (!funcNode || funcNode.type !== 'FunctionDeclaration') return;
+      if (!funcNode.async) return;
+      if (!idNode) return;
+      const name = idNode.name;
+      if (exemptions.has(name)) return;
+      const sugg = ensureAsyncPrefix(name, asyncPrefixes);
+      if (sugg) {
+        suggest(idNode, 'asyncPrefix', { name, prefixes: asyncPrefixes.join(', ') }, sugg);
+      }
+    }
+
+    function checkPluralCollection(idNode, init) {
+      if (!pluralizeFlag) return;
+      const name = idNode.name;
+      if (exemptions.has(name)) return;
+      if (!isCollectionInit(init)) return;
+      if (/(s|List|Set|Map)$/.test(name)) return; // looks plural/collection-like
+      const sugg = pluralize(name);
+      suggest(idNode, 'pluralCollection', { name }, sugg);
+    }
+
+    return {
+      VariableDeclarator(node) {
+        if (!node.id || node.id.type !== 'Identifier') return;
+        const id = node.id;
+        checkStyle(id);
+        checkBooleanPrefix(id, node.init);
+        checkPluralCollection(id, node.init);
+      },
+      FunctionDeclaration(node) {
+        if (node.id) {
+          checkStyle(node.id);
+          checkAsyncFunction(node.id, node);
+        }
+      }
+    };
+  },
+};

--- a/tests/lib/rules/enforce-naming-conventions.js
+++ b/tests/lib/rules/enforce-naming-conventions.js
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Tests for enforce-naming-conventions
+ */
+"use strict";
+
+const rule = require("../../../lib/rules/enforce-naming-conventions"),
+  RuleTester = require("eslint").RuleTester;
+
+const ruleTester = new RuleTester({ languageOptions: { ecmaVersion: 2021, sourceType: 'module' } });
+
+const baseOptions = [{ style: 'camelCase', booleanPrefix: ['is','has'], asyncPrefix: ['fetch','load'], pluralizeCollections: true, maxSuggestions: 1 }];
+
+ruleTester.run("enforce-naming-conventions", rule, {
+  valid: [
+    // Style - already camelCase
+    { code: 'const userProfile = 1;', options: baseOptions },
+    { code: 'function getUser(){}', options: baseOptions },
+
+    // Boolean prefix respected
+    { code: 'const isActive = true;', options: baseOptions },
+
+    // Async prefix respected
+    { code: 'async function fetchUser(){}', options: baseOptions },
+
+    // Pluralized collections
+    { code: 'const users = [];', options: baseOptions },
+    { code: 'const userList = [];', options: baseOptions },
+    { code: 'const idSet = new Set();', options: baseOptions },
+    { code: 'const dataMap = new Map();', options: baseOptions },
+  ],
+  invalid: [
+    // Style: snake_case -> camelCase
+    {
+      code: 'const user_profile = 1;',
+      options: baseOptions,
+      errors: [{ messageId: 'wrongStyle', data: { name: 'user_profile', style: 'camelCase' }, suggestions: [{ messageId: 'suggestRename', output: 'const userProfile = 1;' }] }]
+    },
+
+    // Boolean prefix missing
+    {
+      code: 'const active = true;',
+      options: baseOptions,
+errors: [{ messageId: 'booleanPrefix', data: { name: 'active', prefixes: 'is, has' }, suggestions: [{ messageId: 'suggestRename', output: 'const isActive = true;' }] }]
+    },
+
+    // Async prefix missing
+    {
+      code: 'async function user(){}',
+      options: baseOptions,
+errors: [{ messageId: 'asyncPrefix', data: { name: 'user', prefixes: 'fetch, load' }, suggestions: [{ messageId: 'suggestRename', output: 'async function fetchUser(){}' }] }]
+    },
+
+    // Collection not pluralized
+    {
+      code: 'const user = [];',
+      options: baseOptions,
+      errors: [{ messageId: 'pluralCollection', data: { name: 'user' }, suggestions: [{ messageId: 'suggestRename', output: 'const users = [];' }] }]
+    },
+    {
+      code: 'const item = new Set();',
+      options: baseOptions,
+      errors: [{ messageId: 'pluralCollection', data: { name: 'item' }, suggestions: [{ messageId: 'suggestRename', output: 'const items = new Set();' }] }]
+    },
+    {
+      code: 'const entry = new Map();',
+      options: baseOptions,
+      errors: [{ messageId: 'pluralCollection', data: { name: 'entry' }, suggestions: [{ messageId: 'suggestRename', output: 'const entries = new Map();' }] }]
+    }
+  ]
+});


### PR DESCRIPTION
Implements `enforce-naming-conventions` rule driven by `.ai-coding-guide.json` naming config.

Enforces:
- style: camelCase/snake_case/PascalCase
- booleanPrefix for boolean declarations
- asyncPrefix for async functions
- pluralizeCollections for arrays/Set/Map

Notes:
- Suggestions provided at declaration site (safe, local rename).
- Config + rule options supported; exemptions respected.

Docs/Tests:
- Added docs/rules/enforce-naming-conventions.md
- Comprehensive RuleTester suite; all tests passing (479).
- README updated via eslint-doc-generator.
