### PR TITLE
feat(constants): scaffold constants library with initial domains and helper APIs

### DIFF
--- a/lib/constants/acoustics.js
+++ b/lib/constants/acoustics.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = Object.freeze({
+  constants: [
+    440,    // A4 reference frequency (Hz)
+    44100   // common audio sample rate (Hz)
+  ],
+  terms: [
+    'frequency','pitch','tuning','concert','a4','audio','music','hertz','hz'
+  ]
+});

--- a/lib/constants/astronomy.js
+++ b/lib/constants/astronomy.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = Object.freeze({
+  constants: [
+    // Periods, cycles, etc.
+    365.25, // days in year (approx)
+    29.53059, // synodic month (days)
+    27.32166, // sidereal month (days)
+    27.55455, // anomalistic month (days)
+    27.21222, // draconic month (days)
+  ],
+  terms: [
+    'longitude','latitude','ecliptic','equinox','solstice','aphelion','perihelion','ascending','descending','node',
+    'orbital','orbit','kepler','ephemeris','elements','saros','metonic','draconic','anomalistic','sidereal','synodic','tropical',
+    'motion','velocity','acceleration','angular','epoch','julian','angle','rotation','degree','azimuth'
+  ]
+});

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -1,0 +1,83 @@
+"use strict";
+
+const astronomy = require('./astronomy');
+const units = require('./units');
+const acoustics = require('./acoustics');
+
+const DOMAINS = Object.freeze({
+  astronomy,
+  units,
+  acoustics
+});
+
+const EPS = 1e-12;
+function approxEqual(a, b) {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== 'number' || typeof b !== 'number') return false;
+  return Math.abs(a - b) <= EPS;
+}
+
+function allConstants() {
+  const out = [];
+  for (const [domain, mod] of Object.entries(DOMAINS)) {
+    const arr = Array.isArray(mod.constants) ? mod.constants : [];
+    for (const v of arr) {
+      if (typeof v === 'number') out.push({ domain, value: v });
+    }
+  }
+  return out;
+}
+
+function allTerms() {
+  const out = [];
+  for (const [domain, mod] of Object.entries(DOMAINS)) {
+    const arr = Array.isArray(mod.terms) ? mod.terms : [];
+    for (const t of arr) {
+      out.push({ domain, term: String(t) });
+    }
+  }
+  return out;
+}
+
+function isPhysicalConstant(value) {
+  if (typeof value !== 'number') return false;
+  for (const { value: v } of allConstants()) {
+    if (approxEqual(v, value)) return true;
+  }
+  return false;
+}
+
+function hasScientificTerm(name) {
+  const lower = String(name || '').toLowerCase();
+  if (!lower) return false;
+  for (const { term } of allTerms()) {
+    const lt = term.toLowerCase();
+    if (lt && lower.includes(lt)) return true;
+  }
+  return false;
+}
+
+function getDomainForValue(value) {
+  if (typeof value !== 'number') return null;
+  for (const { domain, value: v } of allConstants()) {
+    if (approxEqual(v, value)) return domain;
+  }
+  return null;
+}
+
+function getDomainForName(name) {
+  const lower = String(name || '').toLowerCase();
+  if (!lower) return null;
+  for (const { domain, term } of allTerms()) {
+    if (lower.includes(term.toLowerCase())) return domain;
+  }
+  return null;
+}
+
+module.exports = {
+  DOMAINS,
+  isPhysicalConstant,
+  hasScientificTerm,
+  getDomainForValue,
+  getDomainForName
+};

--- a/lib/constants/units.js
+++ b/lib/constants/units.js
@@ -1,0 +1,18 @@
+"use strict";
+
+module.exports = Object.freeze({
+  constants: [
+    // Length conversions
+    25.4,   // mm per inch
+    2.54,   // cm per inch
+    0.3048, // m per foot
+    0.0254, // m per inch
+    0.9144, // m per yard
+    1.60934, // km per mile (approx)
+    1.609344 // km per mile (exact in many tables)
+  ],
+  terms: [
+    'meter','metre','inch','foot','feet','mile','centimeter','centimetre','millimeter','millimetre','kilometer','kilometre',
+    'km','cm','mm','mph','kph','yard'
+  ]
+});

--- a/tests/lib/constants/index.js
+++ b/tests/lib/constants/index.js
@@ -1,0 +1,45 @@
+/* eslint-env mocha */
+/* global describe, it */
+"use strict";
+
+const assert = require('assert');
+const {
+  DOMAINS,
+  isPhysicalConstant,
+  hasScientificTerm,
+  getDomainForValue,
+  getDomainForName
+} = require('../../../lib/constants');
+
+describe('constants library', function () {
+  it('exports domains', function () {
+    assert.ok(DOMAINS);
+    assert.ok(DOMAINS.astronomy);
+    assert.ok(DOMAINS.units);
+    assert.ok(DOMAINS.acoustics);
+  });
+
+  it('detects physical constants', function () {
+    assert.strictEqual(isPhysicalConstant(25.4), true);
+    assert.strictEqual(isPhysicalConstant(440), true);
+    assert.strictEqual(isPhysicalConstant(123.456), false);
+  });
+
+  it('detects scientific terms in names', function () {
+    assert.strictEqual(hasScientificTerm('meanLongitude'), true);
+    assert.strictEqual(hasScientificTerm('orbitalPeriod'), true);
+    assert.strictEqual(hasScientificTerm('randomName'), false);
+  });
+
+  it('infers domain for values', function () {
+    assert.strictEqual(getDomainForValue(25.4), 'units');
+    assert.strictEqual(getDomainForValue(440), 'acoustics');
+    assert.strictEqual(getDomainForValue(0.12345), null);
+  });
+
+  it('infers domain for names', function () {
+    assert.strictEqual(getDomainForName('meanLongitude'), 'astronomy');
+    assert.strictEqual(getDomainForName('audioFrequency'), 'acoustics');
+    assert.strictEqual(getDomainForName('fooBar'), null);
+  });
+});


### PR DESCRIPTION
Phase 2.5 scaffold: Introduces `lib/constants/` with initial domains and helper APIs.

What’s included:
- Domains: astronomy, units, acoustics (constants + terms)
- Aggregator + helpers: `isPhysicalConstant(value)`, `hasScientificTerm(name)`, `getDomainForValue(value)`, `getDomainForName(name)`
- Tests: coverage for helpers and domain exports (mocha)

Notes:
- Minimal seed sets intended to be expanded to full library (17 domains, 570+ constants).
- Backwards compatible (no rule changes yet).
- Lint/tests green: 484 passing.
