### PR TITLE
feat(constants): add physics, time, math domains and improve name domain inference

### DIFF
--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -3,11 +3,18 @@
 const astronomy = require('./astronomy');
 const units = require('./units');
 const acoustics = require('./acoustics');
+const physics = require('./physics');
+const time = require('./time');
+const math = require('./math');
 
 const DOMAINS = Object.freeze({
+  // Prioritize generic time-domain matches (e.g., epoch) before astronomy
+  time,
   astronomy,
   units,
-  acoustics
+  acoustics,
+  physics,
+  math
 });
 
 const EPS = 1e-12;

--- a/lib/constants/math.js
+++ b/lib/constants/math.js
@@ -1,0 +1,12 @@
+"use strict";
+
+module.exports = Object.freeze({
+  constants: [
+    3.14159,   // pi (approx)
+    2.71828,   // e (approx)
+    1.61803,   // golden ratio (phi) approx
+  ],
+  terms: [
+    'pi','tau','phi','euler','log','trig','sine','cosine','tangent','rad','deg'
+  ]
+});

--- a/lib/constants/physics.js
+++ b/lib/constants/physics.js
@@ -1,0 +1,13 @@
+"use strict";
+
+// Sources: widely used standard constants (SI)
+module.exports = Object.freeze({
+  constants: [
+    299792458,    // speed of light in vacuum (m/s)
+    9.80665,      // standard gravity (m/s^2)
+    6.67430e-11,  // gravitational constant (m^3 kg^-1 s^-2)
+  ],
+  terms: [
+    'gravity','gravitational','light','vacuum','relativity','planck','newton','force','mass','acceleration','velocity'
+  ]
+});

--- a/lib/constants/time.js
+++ b/lib/constants/time.js
@@ -1,0 +1,14 @@
+"use strict";
+
+module.exports = Object.freeze({
+  constants: [
+    1000,       // milliseconds per second
+    60,         // seconds per minute
+    3600,       // seconds per hour
+    86400,      // seconds per day
+    86400000,   // milliseconds per day
+  ],
+  terms: [
+    'epoch','unix','utc','millisecond','second','minute','hour','day','week','julian'
+  ]
+});

--- a/tests/lib/constants/index.js
+++ b/tests/lib/constants/index.js
@@ -17,11 +17,17 @@ describe('constants library', function () {
     assert.ok(DOMAINS.astronomy);
     assert.ok(DOMAINS.units);
     assert.ok(DOMAINS.acoustics);
+    assert.ok(DOMAINS.physics);
+    assert.ok(DOMAINS.time);
+    assert.ok(DOMAINS.math);
   });
 
   it('detects physical constants', function () {
     assert.strictEqual(isPhysicalConstant(25.4), true);
     assert.strictEqual(isPhysicalConstant(440), true);
+    assert.strictEqual(isPhysicalConstant(299792458), true);
+    assert.strictEqual(isPhysicalConstant(86400), true);
+    assert.strictEqual(isPhysicalConstant(3.14159), true);
     assert.strictEqual(isPhysicalConstant(123.456), false);
   });
 
@@ -34,12 +40,17 @@ describe('constants library', function () {
   it('infers domain for values', function () {
     assert.strictEqual(getDomainForValue(25.4), 'units');
     assert.strictEqual(getDomainForValue(440), 'acoustics');
+    assert.strictEqual(getDomainForValue(299792458), 'physics');
+    assert.strictEqual(getDomainForValue(86400), 'time');
+    assert.strictEqual(getDomainForValue(3.14159), 'math');
     assert.strictEqual(getDomainForValue(0.12345), null);
   });
 
   it('infers domain for names', function () {
     assert.strictEqual(getDomainForName('meanLongitude'), 'astronomy');
     assert.strictEqual(getDomainForName('audioFrequency'), 'acoustics');
+    assert.strictEqual(getDomainForName('standardGravity'), 'physics');
+    assert.strictEqual(getDomainForName('unixEpochMs'), 'time');
     assert.strictEqual(getDomainForName('fooBar'), null);
   });
 });


### PR DESCRIPTION
Phase 2.5: expand constants library with additional domains and name inference improvements.

Adds:
- Domains: physics (c, g, G), time (seconds/day, ms/day), math (pi, e, phi)
- Name inference tweak: prioritize time domain for generic epoch/unix terms before astronomy
- Tests updated to validate detection + domains

Status: lint/tests green (484 passing).

Next: continue expanding remaining domains and add provenance headers; then wire helpers into rules behind config flags.