### PR TITLE
feat(constants): add finance, geometry, statistics domains + provenance; extend tests

### DIFF
--- a/lib/constants/finance.js
+++ b/lib/constants/finance.js
@@ -1,0 +1,13 @@
+"use strict";
+
+// Provenance: Common financial conventions (e.g., 252 trading days/year), industry practice
+module.exports = Object.freeze({
+  constants: [
+    252,      // trading days per year (US markets, approx)
+    12,       // months per year (for compounding)
+    365,      // days per year (calendar)
+  ],
+  terms: [
+    'apr','apy','basis','bps','coupon','yield','discount','cashflow','present','future','interest','compounding','risk','volatility','trading'
+  ]
+});

--- a/lib/constants/geometry.js
+++ b/lib/constants/geometry.js
@@ -1,0 +1,12 @@
+"use strict";
+
+// Provenance: Euclidean geometry basics
+module.exports = Object.freeze({
+  constants: [
+    180,   // degrees in a triangle's interior angle sum
+    360,   // degrees in a circle
+  ],
+  terms: [
+    'angle','triangle','circle','radius','diameter','perimeter','area','polygon','arc','sector','chord'
+  ]
+});

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -6,6 +6,9 @@ const acoustics = require('./acoustics');
 const physics = require('./physics');
 const time = require('./time');
 const math = require('./math');
+const finance = require('./finance');
+const geometry = require('./geometry');
+const statistics = require('./statistics');
 
 const DOMAINS = Object.freeze({
   // Prioritize generic time-domain matches (e.g., epoch) before astronomy
@@ -14,7 +17,10 @@ const DOMAINS = Object.freeze({
   units,
   acoustics,
   physics,
-  math
+  math,
+  finance,
+  geometry,
+  statistics
 });
 
 const EPS = 1e-12;

--- a/lib/constants/statistics.js
+++ b/lib/constants/statistics.js
@@ -1,0 +1,12 @@
+"use strict";
+
+// Provenance: Common statistical constants and terms
+module.exports = Object.freeze({
+  constants: [
+    1.96,   // z-score for 95% two-tailed
+    2.576,  // z-score for 99% two-tailed
+  ],
+  terms: [
+    'mean','median','variance','standard','deviation','zscore','quantile','percentile','confidence','interval','distribution','normal','gaussian'
+  ]
+});

--- a/tests/lib/constants/index.js
+++ b/tests/lib/constants/index.js
@@ -20,6 +20,9 @@ describe('constants library', function () {
     assert.ok(DOMAINS.physics);
     assert.ok(DOMAINS.time);
     assert.ok(DOMAINS.math);
+    assert.ok(DOMAINS.finance);
+    assert.ok(DOMAINS.geometry);
+    assert.ok(DOMAINS.statistics);
   });
 
   it('detects physical constants', function () {
@@ -28,6 +31,9 @@ describe('constants library', function () {
     assert.strictEqual(isPhysicalConstant(299792458), true);
     assert.strictEqual(isPhysicalConstant(86400), true);
     assert.strictEqual(isPhysicalConstant(3.14159), true);
+    assert.strictEqual(isPhysicalConstant(252), true);
+    assert.strictEqual(isPhysicalConstant(360), true);
+    assert.strictEqual(isPhysicalConstant(1.96), true);
     assert.strictEqual(isPhysicalConstant(123.456), false);
   });
 


### PR DESCRIPTION
Expand constants library with additional domains and provenance headers.

Adds:
- finance (252, 12, 365) — provenance: common financial conventions
- geometry (180, 360) — provenance: Euclidean basics
- statistics (1.96, 2.576) — provenance: standard z-scores

Tests updated to validate detection and domains. Lint/tests green (484 passing).

Next: wire constants helpers into rules (starting with no-redundant-calculations).