### PR TITLE
feat(constants): add biology/chemistry/cs/networking/graphics/geodesy + better name inference

### DIFF
--- a/lib/constants/biology.js
+++ b/lib/constants/biology.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// Provenance: General biology terminology
+module.exports = Object.freeze({
+  constants: [
+    // Intentionally empty (avoid overfitting numeric biology constants here)
+  ],
+  terms: [
+    'genome','gene','protein','cell','enzyme','metabolism','neuron','synapse','organism','species','sequence','dna','rna'
+  ]
+});

--- a/lib/constants/chemistry.js
+++ b/lib/constants/chemistry.js
@@ -1,0 +1,12 @@
+"use strict";
+
+// Provenance: Standard chemistry constants
+module.exports = Object.freeze({
+  constants: [
+    6.022e23,  // Avogadro's number (mol^-1)
+    8.314,     // Gas constant R (J mol^-1 K^-1)
+  ],
+  terms: [
+    'mole','molar','avogadro','enthalpy','entropy','enthalpy','reaction','bond','stoichiometry','valence','oxidation','reduction'
+  ]
+});

--- a/lib/constants/cs.js
+++ b/lib/constants/cs.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// Provenance: Computer science terminology
+module.exports = Object.freeze({
+  constants: [
+    // Avoid adding numeric constants like 1024 to reduce false positives
+  ],
+  terms: [
+    'algorithm','binary','byte','bit','stack','queue','tree','graph','hash','cache','memory','pointer','thread','lock','mutex','async'
+  ]
+});

--- a/lib/constants/geodesy.js
+++ b/lib/constants/geodesy.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// Provenance: Geodesy and geospatial terminology
+module.exports = Object.freeze({
+  constants: [
+    // Keep numeric constants minimal to avoid broad matches
+  ],
+  terms: [
+'geodesy','geodetic','geodesic','latitude','longitude','meridian','parallel','ellipsoid','datum','utm','wgs','bearing','azimuth'
+  ]
+});

--- a/lib/constants/graphics.js
+++ b/lib/constants/graphics.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// Provenance: Computer graphics terminology
+module.exports = Object.freeze({
+  constants: [
+    // Avoid numeric color-space constants to limit interference
+  ],
+  terms: [
+    'rgba','alpha','gamma','render','shader','texture','vertex','fragment','antialias','depth','stencil','occlusion'
+  ]
+});

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -9,6 +9,12 @@ const math = require('./math');
 const finance = require('./finance');
 const geometry = require('./geometry');
 const statistics = require('./statistics');
+const biology = require('./biology');
+const chemistry = require('./chemistry');
+const cs = require('./cs');
+const networking = require('./networking');
+const graphics = require('./graphics');
+const geodesy = require('./geodesy');
 
 const DOMAINS = Object.freeze({
   // Prioritize generic time-domain matches (e.g., epoch) before astronomy
@@ -20,7 +26,13 @@ const DOMAINS = Object.freeze({
   math,
   finance,
   geometry,
-  statistics
+  statistics,
+  biology,
+  chemistry,
+  cs,
+networking,
+  graphics,
+  geodesy
 });
 
 const EPS = 1e-12;
@@ -81,11 +93,25 @@ function getDomainForValue(value) {
 function getDomainForName(name) {
   const lower = String(name || '').toLowerCase();
   if (!lower) return null;
+  const matches = [];
   for (const { domain, term } of allTerms()) {
-    if (lower.includes(term.toLowerCase())) return domain;
+    const t = term.toLowerCase();
+    const idx = lower.indexOf(t);
+    if (idx !== -1) {
+      matches.push({ domain, term: t, len: t.length, idx, rank: DOMAIN_RANK[domain] ?? 1e9 });
+    }
   }
-  return null;
+  if (!matches.length) return null;
+  matches.sort((a, b) => {
+    if (b.len !== a.len) return b.len - a.len; // longer term first
+    if (a.idx !== b.idx) return a.idx - b.idx; // earlier occurrence first
+    return a.rank - b.rank; // domain priority
+  });
+  return matches[0].domain;
 }
+
+const DOMAIN_ORDER = Object.freeze(Object.keys(DOMAINS));
+const DOMAIN_RANK = DOMAIN_ORDER.reduce((acc, d, i) => { acc[d] = i; return acc; }, {});
 
 module.exports = {
   DOMAINS,

--- a/lib/constants/networking.js
+++ b/lib/constants/networking.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// Provenance: Networking terminology
+module.exports = Object.freeze({
+  constants: [
+    // Avoid well-known port numbers as numeric constants to reduce noise
+  ],
+  terms: [
+    'ip','ipv4','ipv6','tcp','udp','port','socket','packet','latency','throughput','bandwidth','dns','http','https','tls'
+  ]
+});

--- a/lib/constants/statistics.js
+++ b/lib/constants/statistics.js
@@ -7,6 +7,6 @@ module.exports = Object.freeze({
     2.576,  // z-score for 99% two-tailed
   ],
   terms: [
-    'mean','median','variance','standard','deviation','zscore','quantile','percentile','confidence','interval','distribution','normal','gaussian'
+'mean','median','variance','stddev','stdev','zscore','quantile','percentile','confidence','interval','distribution','normal','gaussian'
   ]
 });

--- a/tests/lib/constants/index.js
+++ b/tests/lib/constants/index.js
@@ -23,6 +23,12 @@ describe('constants library', function () {
     assert.ok(DOMAINS.finance);
     assert.ok(DOMAINS.geometry);
     assert.ok(DOMAINS.statistics);
+    assert.ok(DOMAINS.biology);
+    assert.ok(DOMAINS.chemistry);
+    assert.ok(DOMAINS.cs);
+    assert.ok(DOMAINS.networking);
+    assert.ok(DOMAINS.graphics);
+    assert.ok(DOMAINS.geodesy);
   });
 
   it('detects physical constants', function () {
@@ -57,6 +63,12 @@ describe('constants library', function () {
     assert.strictEqual(getDomainForName('audioFrequency'), 'acoustics');
     assert.strictEqual(getDomainForName('standardGravity'), 'physics');
     assert.strictEqual(getDomainForName('unixEpochMs'), 'time');
+    assert.strictEqual(getDomainForName('avogadroConstant'), 'chemistry');
+    assert.strictEqual(getDomainForName('hashMap'), 'cs');
+    assert.strictEqual(getDomainForName('ipAddress'), 'networking');
+    assert.strictEqual(getDomainForName('rgbaColor'), 'graphics');
+    assert.strictEqual(getDomainForName('geodesicLatitude'), 'geodesy');
+    assert.strictEqual(getDomainForName('genomeSequence'), 'biology');
     assert.strictEqual(getDomainForName('fooBar'), null);
   });
 });


### PR DESCRIPTION
Phase 2.5: add additional domains (biology, chemistry, CS, networking, graphics, geodesy), improve name-domain inference, and refine statistics terms to reduce false matches.

- New domains with provenance notes and terms (minimal numeric constants to avoid noise)
- Name inference now selects the longest term match, earliest index, then domain priority
- Adjusted statistics terms (stddev/stdev) to avoid generic matches like 'standard'
- Tests added/updated; all green (484 passing)
