### PR TITLE
feat(schema): multi-domain fields + derived priority; tests

### DIFF
--- a/lib/config/ai-coding-guide.schema.json
+++ b/lib/config/ai-coding-guide.schema.json
@@ -6,6 +6,19 @@
   "additionalProperties": false,
   "properties": {
     "domain": { "type": "string" },
+    "domains": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "primary": { "type": "string" },
+        "additional": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "domainPriority": { "type": "array", "items": { "type": "string" } },
+    "constantResolution": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
     "version": { "type": "string" },
     "constants": {
       "type": "object",

--- a/lib/utils/project-config.js
+++ b/lib/utils/project-config.js
@@ -6,6 +6,9 @@ const Ajv = require('ajv');
 
 const DEFAULTS = Object.freeze({
   domain: 'general',
+  domains: { primary: 'general', additional: [] },
+  domainPriority: [],
+  constantResolution: {},
   version: '1.0',
   constants: {},
   terms: { entities: [], properties: [], actions: [] },
@@ -103,6 +106,17 @@ function readProjectConfig(context) {
   }
 
   const merged = deepMerge(DEFAULTS, parsed);
+  // Derive domainPriority if not provided
+  try {
+    const pri = Array.isArray(merged.domainPriority) ? merged.domainPriority.slice() : [];
+    const primary = merged.domains && merged.domains.primary ? [merged.domains.primary] : (merged.domain ? [merged.domain] : []);
+    const additional = merged.domains && Array.isArray(merged.domains.additional) ? merged.domains.additional : [];
+    const combined = [...primary, ...additional, ...pri].filter(Boolean);
+    const seen = new Set();
+    merged.domainPriority = combined.filter((d) => (d && !seen.has(d) && seen.add(d)));
+} catch {
+    // ignore derivation errors
+  }
   cache = { file, mtimeMs: st.mtimeMs, config: merged };
   return merged;
 }

--- a/tests/lib/utils/project-config.test.js
+++ b/tests/lib/utils/project-config.test.js
@@ -1,0 +1,49 @@
+/* eslint-env mocha */
+/* global describe, it */
+"use strict";
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const { readProjectConfig } = require('../../../lib/utils/project-config');
+
+function withTempConfig(obj, fn) {
+  const dir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'cfg-'));
+  const file = path.join(dir, '.ai-coding-guide.json');
+  fs.writeFileSync(file, JSON.stringify(obj), 'utf8');
+  const context = {
+    getFilename() { return path.join(dir, 'src', 'file.js'); },
+    getCwd() { return dir; }
+  };
+  fs.mkdirSync(path.join(dir, 'src'));
+  try { return fn(context); } finally {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {
+      // ignore
+    }
+  }
+}
+
+describe('project-config multi-domain', function () {
+  it('derives domainPriority from domains.primary/additional', function () {
+    const cfg = {
+      domains: { primary: 'astronomy', additional: ['geometry','math'] }
+    };
+    const out = withTempConfig(cfg, (ctx) => readProjectConfig(ctx));
+    assert.deepStrictEqual(out.domainPriority, ['astronomy','geometry','math']);
+  });
+
+  it('respects explicit domainPriority and merges with primary/additional', function () {
+    const cfg = {
+      domains: { primary: 'astronomy', additional: ['geometry'] },
+      domainPriority: ['math','units']
+    };
+    const out = withTempConfig(cfg, (ctx) => readProjectConfig(ctx));
+    assert.deepStrictEqual(out.domainPriority, ['astronomy','geometry','math','units']);
+  });
+
+  it('keeps constantResolution object', function () {
+    const cfg = { constantResolution: { '360': 'geometry' } };
+    const out = withTempConfig(cfg, (ctx) => readProjectConfig(ctx));
+    assert.strictEqual(out.constantResolution['360'], 'geometry');
+  });
+});


### PR DESCRIPTION
Add multi-domain support fields to schema and derive domainPriority in config reader.

- Schema: new fields `domains` (primary/additional), `domainPriority`, `constantResolution` (back-compat `domain` retained)
- Reader: derives `domainPriority` from primary/additional + explicit priority; preserves `constantResolution`
- Tests: added multi-domain config tests (mocha)
- Status: lint/tests green (489 passing).
