### PR TITLE
feat: ambiguity warnings in NRC + CLI init skeleton

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function parseArgs(argv) {
+  const out = { _: [] };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const [k, v] = a.replace(/^--/, '').split('=');
+      out[k] = v === undefined ? true : v;
+    } else {
+      out._.push(a);
+    }
+  }
+  return out;
+}
+
+function writeConfig(cwd, cfg) {
+  const file = path.join(cwd, '.ai-coding-guide.json');
+  if (fs.existsSync(file) && !process.env.FORCE_AI_CONFIG) {
+    console.log(`Found existing ${file} — use FORCE_AI_CONFIG=1 to overwrite.`);
+    return 0;
+  }
+  fs.writeFileSync(file, JSON.stringify(cfg, null, 2) + '\n');
+  console.log(`Wrote ${file}`);
+  return 0;
+}
+
+function init(cwd, args) {
+  const primary = (args.primary || 'general').trim();
+  const additional = (args.additional || '').split(',').map(s => s.trim()).filter(Boolean);
+  const domainPriority = [primary, ...additional];
+  const cfg = {
+    domains: { primary, additional },
+    domainPriority,
+    constants: {},
+    terms: { entities: [], properties: [], actions: [] },
+    naming: { style: 'camelCase', booleanPrefix: ['is','has','should','can'], asyncPrefix: ['fetch','load','save'], pluralizeCollections: true },
+    antiPatterns: { forbiddenNames: [], forbiddenTerms: [] }
+  };
+  return writeConfig(cwd, cfg);
+}
+
+function usage() {
+  console.log(`Usage: eslint-plugin-ai-code-snifftest init [--primary=<domain>] [--additional=a,b,c]
+
+Examples:
+  eslint-plugin-ai-code-snifftest init --primary=astronomy --additional=geometry,math,units
+`);
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const cmd = args._[0];
+  const cwd = process.cwd();
+  if (cmd === 'init') {
+    process.exitCode = init(cwd, args);
+    return;
+  }
+  usage();
+}
+
+main();

--- a/lib/rules/no-redundant-calculations.js
+++ b/lib/rules/no-redundant-calculations.js
@@ -171,7 +171,8 @@ module.exports = {
     ],
     messages: {
       redundantCalculation: 'Calculate this at compile time: {{ result }}',
-      preserveIntent: 'Keep formula and append computed value'
+      preserveIntent: 'Keep formula and append computed value',
+      ambiguousConstant: 'Constant {{ value }} appears in multiple domains ({{ domains }}); add @domain annotation or set constantResolution'
     },
   },
 
@@ -386,6 +387,13 @@ module.exports = {
 
         // NEW: skip likely scientific formulas
         if (shouldSkipScientificCalculation(node)) {
+          return;
+        }
+
+        // Ambiguity warning: if value maps to multiple domains and not otherwise resolved
+        const matches = matchDomainsForValue(result);
+        if (matches.length > 1 && !shouldSkipByDomainResolution(result, node)) {
+          context.report({ node, messageId: 'ambiguousConstant', data: { value: String(result), domains: matches.join(', ') } });
           return;
         }
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,12 @@
   "main": "./lib/index.js",
   "exports": "./lib/index.js",
   "files": [
-    "lib"
+    "lib",
+    "bin"
   ],
+  "bin": {
+    "eslint-plugin-ai-code-snifftest": "./bin/cli.js"
+  },
   "scripts": {
     "lint": "npm-run-all \"lint:*\"",
     "lint:eslint-docs": "npm-run-all \"update:eslint-docs -- --check\"",


### PR DESCRIPTION
Add ambiguity warnings and CLI skeleton.

- NRC: warn when a computed constant maps to multiple domains and is not resolved via annotations/file domains/constantResolution/priority
- CLI: new bin `eslint-plugin-ai-code-snifftest` with `init` command to write basic multi-domain config (non-interactive flags)
- Package: added bin entry and included bin/ in published files
- Status: lint/tests green (491)
