### PR TITLE
feat(parser): section-level + JSDoc domain annotations

### DIFF
--- a/lib/utils/domain-annotations.js
+++ b/lib/utils/domain-annotations.js
@@ -1,5 +1,43 @@
 "use strict";
 
+// Lightweight cache keyed by SourceCode instance
+const cache = new WeakMap();
+
+function getDomainComments(context) {
+  const src = context.getSourceCode();
+  let entry = cache.get(src);
+  if (!entry) {
+    const all = src.getAllComments ? src.getAllComments() : [];
+    const domainComments = [];
+    for (const c of all || []) {
+      const val = String(c.value || '');
+      const m1 = val.match(/@domain\s+([A-Za-z0-9_-]+)/);
+      const m2 = val.match(/@domains?\s+([A-Za-z0-9_,\s-]+)/);
+      if (m1) domainComments.push({ type: 'single', domain: m1[1], loc: c.loc });
+      else if (m2) domainComments.push({ type: 'multi', domains: m2[1].split(',').map(s=>s.trim()).filter(Boolean), loc: c.loc });
+    }
+    entry = { domainComments };
+    cache.set(src, entry);
+  }
+  return entry.domainComments;
+}
+
+function getNearestSectionDomain(node, context) {
+  try {
+    if (!node.loc) return null;
+    const line = node.loc.start.line;
+    let nearest = null;
+    for (const dc of getDomainComments(context)) {
+      if (dc.type === 'single' && dc.loc && dc.loc.end && dc.loc.end.line < line) {
+        if (!nearest || dc.loc.end.line > nearest.loc.end.line) nearest = dc;
+      }
+    }
+    return nearest ? nearest.domain : null;
+  } catch {
+    return null;
+  }
+}
+
 function getDomainAnnotation(node, context) {
   const src = context.getSourceCode();
   const comments = src.getCommentsBefore(node) || [];
@@ -7,17 +45,16 @@ function getDomainAnnotation(node, context) {
     const m = String(c.value || '').match(/@domain\s+([A-Za-z0-9_-]+)/);
     if (m) return m[1];
   }
+  // Fallback to nearest section-level @domain above this node
+  const section = getNearestSectionDomain(node, context);
+  if (section) return section;
   return null;
 }
 
 function getFileDomains(context) {
-  const src = context.getSourceCode();
-  const all = src.getAllComments ? src.getAllComments() : [];
-  for (const c of (all || []).slice(0, 20)) {
-    const m = String(c.value || '').match(/@domains?\s+([A-Za-z0-9_,\s-]+)/);
-    if (m) {
-      return m[1].split(',').map((s) => s.trim()).filter(Boolean);
-    }
+  // Use cached parsed comments and look for first multi-domain declaration
+  for (const dc of getDomainComments(context)) {
+    if (dc.type === 'multi') return dc.domains;
   }
   return [];
 }

--- a/tests/lib/utils/domain-annotations.test.js
+++ b/tests/lib/utils/domain-annotations.test.js
@@ -45,4 +45,39 @@ describe('domain-annotations', function () {
     linter.verify(`// header\n/* @domain geometry */\nconst y = 360;`, [{ languageOptions: { ecmaVersion: 2021 }, plugins: { test: { rules: { probe2 } } }, rules: { 'test/probe2': 'error' } }]);
     assert.strictEqual(seen, 'geometry');
   });
+
+  it('falls back to nearest section-level @domain above node', function () {
+    const linter = new eslint.Linter();
+    let last = null;
+    const probe3 = {
+      create(context) {
+        return {
+          VariableDeclaration(node) {
+            last = getDomainAnnotation(node, context);
+          }
+        };
+      }
+    };
+    const code = `// banner\n// @domain astronomy\nconst a = 1;\n\n// some text\n// @domain geometry\nfunction f(){}\n\nconst b = 2;`;
+    linter.verify(code, [{ languageOptions: { ecmaVersion: 2021 }, plugins: { test: { rules: { probe3 } } }, rules: { 'test/probe3': 'error' } }]);
+    // The last var decl should pick up geometry section
+    assert.strictEqual(last, 'geometry');
+  });
+
+  it('supports JSDoc @domain on block comment', function () {
+    const linter = new eslint.Linter();
+    let seen = null;
+    const probe4 = {
+      create(context) {
+        return {
+          VariableDeclaration(node) {
+            seen = getDomainAnnotation(node, context);
+          }
+        };
+      }
+    };
+    const code = `/**\n * @domain physics\n */\nconst c = 299792458;`;
+    linter.verify(code, [{ languageOptions: { ecmaVersion: 2021 }, plugins: { test: { rules: { probe4 } } }, rules: { 'test/probe4': 'error' } }]);
+    assert.strictEqual(seen, 'physics');
+  });
 });


### PR DESCRIPTION
Parser enhancements: section-level @domain fallback and JSDoc @domain support with cached comment scan.

- getDomainAnnotation now falls back to nearest preceding @domain in file (section-level)
- JSDoc block comments with @domain are recognized
- Cached domain comment parsing for efficiency
- Tests added for section-level and JSDoc cases (flat-config style)
- Status: tests green
