### PR TITLE
feat: enforce-domain-terms prefer active-domain terms; CLI generate .md/.cursorrules

### DIFF
--- a/lib/rules/enforce-domain-terms.js
+++ b/lib/rules/enforce-domain-terms.js
@@ -6,6 +6,7 @@
 /* eslint-disable eslint-plugin/require-meta-has-suggestions */
 
 const { readProjectConfig } = require('../utils/project-config');
+const { DOMAINS } = require('../constants');
 
 function toPascalCase(s) {
   return String(s || '')
@@ -29,7 +30,22 @@ function hasDomainTerm(name, terms) {
 function collectDomainTerms(project, options) {
   const opt = options && options[0] ? options[0] : {};
   const fromOptions = Array.isArray(opt.requiredTerms) ? opt.requiredTerms : [];
+
+  // Priority: active domains -> project terms/options
+  const priorityDomains = Array.isArray(project?.domainPriority) && project.domainPriority.length
+    ? project.domainPriority
+    : (project?.domains?.primary ? [project.domains.primary, ...(project?.domains?.additional || [])] : []);
+
+  const priorityTerms = [];
+  for (const d of priorityDomains) {
+    const mod = DOMAINS && DOMAINS[d];
+    if (mod && Array.isArray(mod.terms)) {
+      for (const t of mod.terms) priorityTerms.push(String(t));
+    }
+  }
+
   const terms = new Set();
+  for (const t of priorityTerms) terms.add(t);
   for (const t of fromOptions) terms.add(String(t));
 
   const cfg = project && project.terms ? project.terms : {};


### PR DESCRIPTION
Prefer active-domain terms in enforce-domain-terms; extend CLI init to generate docs.

- Rule: suggestions are now prioritized from active domains (via config domainPriority / domains.primary+additional)
- CLI: `init` can generate `.ai-coding-guide.md` and `.cursorrules` (flags or interactive prompt)
- Lint/tests green (493).
