### PR TITLE
feat(constants): add civil and photo domains (17 total)

### DIFF
--- a/lib/constants/civil.js
+++ b/lib/constants/civil.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// Provenance: Civil engineering terminology (structures/materials)
+module.exports = Object.freeze({
+  constants: [
+    // Keep minimal numerics to avoid false positives
+  ],
+  terms: [
+    'beam','girder','truss','shear','stress','strain','load','moment','torque','reinforced','concrete','steel','foundation','bridge','column','deflection'
+  ]
+});

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -15,6 +15,8 @@ const cs = require('./cs');
 const networking = require('./networking');
 const graphics = require('./graphics');
 const geodesy = require('./geodesy');
+const civil = require('./civil');
+const photo = require('./photo');
 
 const DOMAINS = Object.freeze({
   // Prioritize generic time-domain matches (e.g., epoch) before astronomy
@@ -32,7 +34,9 @@ const DOMAINS = Object.freeze({
   cs,
 networking,
   graphics,
-  geodesy
+  geodesy,
+  civil,
+  photo
 });
 
 const EPS = 1e-12;

--- a/lib/constants/photo.js
+++ b/lib/constants/photo.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// Provenance: Photography terminology (exposure)
+module.exports = Object.freeze({
+  constants: [
+    // Avoid numeric constants (exposure values depend on context)
+  ],
+  terms: [
+    'exposure','aperture','shutter','iso','sensor','lens','fstop','bokeh','histogram','whitebalance','gamma','raw','jpeg'
+  ]
+});

--- a/tests/lib/constants/index.js
+++ b/tests/lib/constants/index.js
@@ -29,6 +29,8 @@ describe('constants library', function () {
     assert.ok(DOMAINS.networking);
     assert.ok(DOMAINS.graphics);
     assert.ok(DOMAINS.geodesy);
+    assert.ok(DOMAINS.civil);
+    assert.ok(DOMAINS.photo);
   });
 
   it('detects physical constants', function () {
@@ -69,6 +71,8 @@ describe('constants library', function () {
     assert.strictEqual(getDomainForName('rgbaColor'), 'graphics');
     assert.strictEqual(getDomainForName('geodesicLatitude'), 'geodesy');
     assert.strictEqual(getDomainForName('genomeSequence'), 'biology');
+    assert.strictEqual(getDomainForName('shearStress'), 'civil');
+    assert.strictEqual(getDomainForName('apertureValue'), 'photo');
     assert.strictEqual(getDomainForName('fooBar'), null);
   });
 });


### PR DESCRIPTION
Add final two domains to reach 17: civil (structures/materials) and photo (photography/exposure).

- New domains with provenance notes; minimal numeric constants to avoid false positives
- Name inference extended for sample terms (shearStress → civil, apertureValue → photo)
- Tests and lint green (493).
