### PR TITLE
test(nrc): domain-resolution integration; feat(nrc): honor constantResolution mapping

### DIFF
--- a/lib/rules/no-redundant-calculations.js
+++ b/lib/rules/no-redundant-calculations.js
@@ -345,7 +345,7 @@ module.exports = {
       // 4) Explicit constantResolution
       const map = projectConfig.constantResolution || {};
       const key = String(value);
-      if (map[key] && matchDomainsForValue(value).includes(map[key])) return true;
+      if (map[key]) return true;
       // 5) Primary/domainPriority
       const pri = Array.isArray(projectConfig.domainPriority) ? projectConfig.domainPriority : [];
       if (pri.length) {

--- a/tests/integration/nrc-domain-resolution.test.js
+++ b/tests/integration/nrc-domain-resolution.test.js
@@ -1,0 +1,41 @@
+/* eslint-env mocha */
+"use strict";
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../lib/rules/no-redundant-calculations');
+
+function tempConfigWithResolution(map) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nrc-'));
+  const file = path.join(dir, '.ai-coding-guide.json');
+  const cfg = { constantResolution: map };
+  fs.writeFileSync(file, JSON.stringify(cfg), 'utf8');
+  const srcDir = path.join(dir, 'src');
+  fs.mkdirSync(srcDir);
+  return { dir, filename: path.join(srcDir, 'a.js') };
+}
+
+const tester = new RuleTester({ languageOptions: { ecmaVersion: 2021, sourceType: 'module' } });
+
+tester.run('no-redundant-calculations (integration: domain resolution)', rule, {
+  valid: [
+    // File-level @domains geometry should allow 720/2 (=360)
+    {
+      code: `// @domains geometry\nconst deg = 720 / 2;`,
+    },
+    // Name-based: includes geometry term
+    {
+      code: `const circleAngle = 720 / 2;`,
+    },
+    // constantResolution mapping 360->geometry
+    (() => {
+      const t = tempConfigWithResolution({ '360': 'geometry' });
+      return {
+        code: `const z = 720 / 2;`,
+        filename: t.filename
+      };
+    })(),
+  ],
+  invalid: []
+});


### PR DESCRIPTION
Integration tests for NRC domain resolution + constantResolution; tweak NRC to honor explicit constantResolution even without declared constants.

- Tests: file-level @domains geometry, name-based, and constantResolution mapping
- Rule: constantResolution now authoritative for skip
- Status: lint/tests green (497).
