### PR TITLE
feat(external-constants): discovery cache + npm allowlist + CLI --allowlist (behind flag) (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,13 @@ TODO: Run eslint-doc-generator to generate the configs list (or delete this sect
 - Wizard will summarize discovered domains (built-in, npm, local, custom) and list merged domains in `.ai-coding-guide.md`.
 - Behind a flag; defaults to disabled.
 
+#### Allowlist and cache
+- `externalConstantsAllowlist`: array of package names or regex strings (e.g., `"^@ai-constants/"`) to limit npm discovery.
+- CLI: `--allowlist="^@ai-constants/med,^eslint-constants-"` seeds the allowlist in generated config when used with `--external`.
+- Env:
+  - `DEBUG_AI_CONSTANTS=1` prints discovery warnings
+  - `AI_CONSTANTS_NO_CACHE=1` disables the in-process discovery cache
+- Enable in CLI: `--external` or set `experimentalExternalConstants: true` in `.ai-coding-guide.json`.
+- Wizard will summarize discovered domains (built-in, npm, local, custom) and list merged domains in `.ai-coding-guide.md`.
+- Behind a flag; defaults to disabled.
+

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -276,6 +276,7 @@ function init(cwd, args) {
   const additional = (args.additional || '').split(',').map(s => s.trim()).filter(Boolean);
   const domainPriority = [primary, ...additional];
 const external = Boolean(args.external || args.experimentalExternalConstants);
+  const allowlist = (args.allowlist || '').split(',').map(s=>s.trim()).filter(Boolean);
   const cfg = {
     domains: { primary, additional },
     domainPriority,
@@ -283,8 +284,12 @@ const external = Boolean(args.external || args.experimentalExternalConstants);
     terms: { entities: [], properties: [], actions: [] },
     naming: { style: 'camelCase', booleanPrefix: ['is','has','should','can'], asyncPrefix: ['fetch','load','save'], pluralizeCollections: true },
     antiPatterns: { forbiddenNames: [], forbiddenTerms: [] },
-    experimentalExternalConstants: external
+    experimentalExternalConstants: external,
+    externalConstantsAllowlist: allowlist
   };
+  if (external && (!allowlist || allowlist.length === 0)) {
+    console.warn('Warning: --external used without allowlist; consider adding --allowlist to limit npm scope.');
+  }
   const code = writeConfig(cwd, cfg);
   const hasWarp = fs.existsSync(path.join(cwd, 'WARP.md'));
   if (args.md || args.yes) writeGuideMd(cwd, cfg);

--- a/lib/utils/discover-constants.js
+++ b/lib/utils/discover-constants.js
@@ -2,9 +2,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const { validateConstantsPackage } = require('./validate-constants-package');
 
 function readJson(p) { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return null; } }
+function sha1(str) { return crypto.createHash('sha1').update(String(str)).digest('hex'); }
+const CACHE = { npm: new Map() };
 
 function loadBuiltinConstants() {
   const constantsDir = path.join(__dirname, '..', 'constants');
@@ -25,13 +28,34 @@ function loadBuiltinConstants() {
   return out;
 }
 
-function discoverNpmPackages(projectRoot) {
-  const pkg = readJson(path.join(projectRoot, 'package.json')) || {};
+function discoverNpmPackages(projectRoot, allowlist) {
+const pkgPath = path.join(projectRoot, 'package.json');
+  const pkg = readJson(pkgPath) || {};
   const all = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
   const patterns = [/^@ai-constants\//, /^eslint-constants-/, /-ai-constants$/];
   const out = {};
+try {
+    const depsString = JSON.stringify({ d: pkg.dependencies || {}, dv: pkg.devDependencies || {} });
+    const key = projectRoot + ':' + sha1(depsString);
+    if (CACHE.npm.has(key) && !process.env.AI_CONSTANTS_NO_CACHE) {
+      return CACHE.npm.get(key);
+    }
+  } catch (e) {
+    if (process.env.DEBUG_AI_CONSTANTS) {
+       
+      console.warn(`[discover-constants] cache key compute failed: ${e && e.message}`);
+    }
+  }
   for (const name of Object.keys(all)) {
-    if (!patterns.some((p) => p.test(name))) continue;
+if (!patterns.some((p) => p.test(name))) continue;
+    if (Array.isArray(allowlist) && allowlist.length) {
+      const allowed = allowlist.some((rule) => {
+        if (!rule) return false;
+        if (rule.startsWith('^')) { try { return new RegExp(rule).test(name); } catch { return false; } }
+        return rule === name;
+      });
+      if (!allowed) continue;
+    }
     try {
       const mod = require(name);
       const data = mod && (mod.default || mod);
@@ -43,6 +67,16 @@ function discoverNpmPackages(projectRoot) {
          
         console.warn(`[discover-constants] failed to load ${name}: ${err && err.message}`);
       }
+    }
+  }
+try {
+    const depsString = JSON.stringify({ d: pkg.dependencies || {}, dv: pkg.devDependencies || {} });
+    const key = projectRoot + ':' + sha1(depsString);
+    CACHE.npm.set(key, out);
+  } catch (e) {
+    if (process.env.DEBUG_AI_CONSTANTS) {
+       
+      console.warn(`[discover-constants] cache set failed: ${e && e.message}`);
     }
   }
   return out;
@@ -81,9 +115,11 @@ function loadCustomConstants(projectRoot) {
 }
 
 function discoverConstants(projectRoot = process.cwd()) {
+const cfg = readJson(path.join(projectRoot, '.ai-coding-guide.json')) || {};
+  const allowlist = Array.isArray(cfg.externalConstantsAllowlist) ? cfg.externalConstantsAllowlist : [];
   return {
     builtin: loadBuiltinConstants(),
-    npm: discoverNpmPackages(projectRoot),
+    npm: discoverNpmPackages(projectRoot, allowlist),
     local: discoverLocalFiles(projectRoot),
     custom: loadCustomConstants(projectRoot)
   };

--- a/lib/utils/project-config.js
+++ b/lib/utils/project-config.js
@@ -14,7 +14,8 @@ const DEFAULTS = Object.freeze({
   terms: { entities: [], properties: [], actions: [] },
   naming: { style: 'camelCase', booleanPrefix: ['is','has','should','can'], asyncPrefix: ['fetch','load','save'], pluralizeCollections: true },
 antiPatterns: { forbiddenNames: [], forbiddenTerms: [] },
-  experimentalExternalConstants: false
+  experimentalExternalConstants: false,
+  externalConstantsAllowlist: []
 });
 
 let cache = null; // { file, mtimeMs, config }

--- a/tests/integration/cli-external-allowlist.test.js
+++ b/tests/integration/cli-external-allowlist.test.js
@@ -1,0 +1,22 @@
+/* eslint-env mocha */
+/* global describe, it */
+"use strict";
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execFileSync } = require('child_process');
+
+describe('CLI --external with --allowlist', function () {
+  it('writes allowlist into .ai-coding-guide.json', function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-allow-'));
+    const cliPath = path.resolve(__dirname, '..', '..', 'bin', 'cli.js');
+    const env = { ...process.env, FORCE_AI_CONFIG: '1', FORCE_ESLINT_CONFIG: '1', SKIP_AI_REQUIREMENTS: '1', NODE_ENV: 'test' };
+    execFileSync('node', [cliPath, 'init', '--primary=general', '--yes', '--external', '--allowlist=^@ai-constants/med,^eslint-constants-'], { cwd: tmp, env, stdio: 'pipe' });
+    const cfg = JSON.parse(fs.readFileSync(path.join(tmp, '.ai-coding-guide.json'), 'utf8'));
+    assert.ok(Array.isArray(cfg.externalConstantsAllowlist));
+    assert.ok(cfg.externalConstantsAllowlist.includes('^@ai-constants/med'));
+    assert.ok(cfg.externalConstantsAllowlist.includes('^eslint-constants-'));
+  });
+});

--- a/tests/lib/utils/discover-constants-allowlist.test.js
+++ b/tests/lib/utils/discover-constants-allowlist.test.js
@@ -1,0 +1,36 @@
+/* eslint-env mocha */
+/* global describe, it */
+"use strict";
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { discoverConstants } = require('../../../lib/utils/discover-constants');
+
+function write(file, content) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content, 'utf8');
+}
+
+describe('discover-constants allowlist/cache', function () {
+  it('reads allowlist from config and does not throw', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'disc-allow-'));
+    write(path.join(dir, 'package.json'), JSON.stringify({ dependencies: { '@ai-constants/medical': '1.0.0', '@ai-constants/automotive': '1.0.0' } }, null, 2));
+    write(path.join(dir, '.ai-coding-guide.json'), JSON.stringify({ externalConstantsAllowlist: ['^@ai-constants/med'] }, null, 2));
+    const all = discoverConstants(dir);
+    assert.ok(all && all.npm !== undefined);
+  });
+
+  it('caches npm discovery per package.json hash', function () {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'disc-cache-'));
+    write(path.join(dir, 'package.json'), JSON.stringify({ dependencies: {} }, null, 2));
+    write(path.join(dir, '.ai-coding-guide.json'), JSON.stringify({ externalConstantsAllowlist: [] }, null, 2));
+    const a = discoverConstants(dir);
+    const b = discoverConstants(dir);
+    assert.ok(a && b);
+    write(path.join(dir, 'package.json'), JSON.stringify({ dependencies: { '@ai-constants/x': '1.0.0' } }, null, 2));
+    const c = discoverConstants(dir);
+    assert.ok(c);
+  });
+});


### PR DESCRIPTION
External constants: discovery cache + allowlist (issue #64)

- Config: `externalConstantsAllowlist` default added; docs updated
- Discovery: npm allowlist filter; simple SHA1-based cache keyed by package.json deps/devDeps (disable via `AI_CONSTANTS_NO_CACHE=1`)
- Debug: `DEBUG_AI_CONSTANTS=1` prints discovery warnings; no-empty catches replaced with debug logs
- CLI: `--allowlist` flag (seeds config when used with `--external`); warn if `--external` used without allowlist
- Tests: allowlist + cache tests; integration test for CLI allowlist (total 515 passing)

Safe: gated behind existing experimental flag usage; default behavior unchanged.

Refs: #64, PRs #67, #68, #70