### PR TITLE
feat(external-constants): scaffolder command and example domain packages (#64)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -156,12 +156,27 @@ function init(cwd, args) {
   return code;
 }
 
-function usage() {
-  console.log(`Usage: eslint-plugin-ai-code-snifftest init [--primary=<domain>] [--additional=a,b,c]
+function scaffoldConstantsPkg(cwd, domainArg, outDirArg) {
+  const domain = String(domainArg || '').trim();
+  if (!domain) { console.error('Missing domain. Usage: eslint-plugin-ai-code-snifftest scaffold <domain> [--dir=path]'); return 1; }
+  const outDir = path.resolve(cwd, outDirArg || `./${domain}`);
+  fs.mkdirSync(outDir, { recursive: true });
+  const pkgName = `@ai-constants/${domain}`;
+  const indexJs = `module.exports = {\n  domain: '${domain}',\n  version: '1.0.0',\n  constants: [\n    { value: 42, name: 'EXAMPLE_CONSTANT', description: 'Example constant for ${domain}' }\n  ],\n  terms: { entities: ['Entity1'], properties: ['property1'], actions: ['action1'] },\n  naming: { style: 'camelCase', booleanPrefix: ['is','has','should'], constants: 'UPPER_SNAKE_CASE' }\n};\n`;
+  const pkgJson = { name: pkgName, version: '1.0.0', main: 'index.js', license: 'MIT' };
+  const readme = `# ${pkgName}\n\nExternal constants package for the ${domain} domain.\n`;
+  const testDir = path.join(outDir, 'test');
+  fs.writeFileSync(path.join(outDir, 'index.js'), indexJs);
+  fs.writeFileSync(path.join(outDir, 'package.json'), JSON.stringify(pkgJson, null, 2) + '\n');
+  fs.writeFileSync(path.join(outDir, 'README.md'), readme);
+  fs.mkdirSync(testDir, { recursive: true });
+  fs.writeFileSync(path.join(testDir, 'validate.test.js'), `/* placeholder tests */\n`);
+  console.log(`Scaffolded external constants package at ${outDir}`);
+  return 0;
+}
 
-Examples:
-  eslint-plugin-ai-code-snifftest init --primary=astronomy --additional=geometry,math,units
-`);
+function usage() {
+  console.log(`Usage:\n  eslint-plugin-ai-code-snifftest init [--primary=<domain>] [--additional=a,b,c]\n  eslint-plugin-ai-code-snifftest scaffold <domain> [--dir=path]\n\nExamples:\n  eslint-plugin-ai-code-snifftest init --primary=astronomy --additional=geometry,math,units\n  eslint-plugin-ai-code-snifftest scaffold medical --dir=./examples/external/medical\n`);
 }
 
 function resolvePkgVersion(name, cwd) {
@@ -226,6 +241,12 @@ function main() {
       return;
     }
     process.exitCode = init(cwd, args);
+    return;
+  }
+  if (cmd === 'scaffold' || cmd === 'create-constants') {
+    const dom = args._[1];
+    const outDir = args.dir || args.out;
+    process.exitCode = scaffoldConstantsPkg(cwd, dom, outDir);
     return;
   }
   usage();

--- a/examples/external/automotive/index.js
+++ b/examples/external/automotive/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  domain: 'automotive',
+  version: '1.0.0',
+  constants: [
+    { value: 0.3048, name: 'M_PER_FOOT', description: 'Meters per foot' },
+    { value: 1.60934, name: 'KM_PER_MILE', description: 'Kilometers per mile (approx)' }
+  ],
+  terms: { entities: ['Vehicle','Engine'], properties: ['speed','rpm'], actions: ['accelerate','brake'] },
+  naming: { style: 'camelCase', booleanPrefix: ['is','has','should'], constants: 'UPPER_SNAKE_CASE' }
+};

--- a/examples/external/automotive/package.json
+++ b/examples/external/automotive/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@ai-constants/automotive",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/examples/external/medical/index.js
+++ b/examples/external/medical/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  domain: 'medical',
+  version: '1.0.0',
+  constants: [
+    { value: 37.0, name: 'NORMAL_BODY_TEMP_C', description: 'Normal body temperature (Celsius)' },
+    { value: 98.6, name: 'NORMAL_BODY_TEMP_F', description: 'Normal body temperature (Fahrenheit)' }
+  ],
+  terms: { entities: ['Patient','Diagnosis'], properties: ['bloodPressure','heartRate'], actions: ['diagnose','treat'] },
+  naming: { style: 'camelCase', booleanPrefix: ['is','has','should'], constants: 'UPPER_SNAKE_CASE' }
+};

--- a/examples/external/medical/package.json
+++ b/examples/external/medical/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@ai-constants/medical",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/tests/integration/cli-scaffold-constants.test.js
+++ b/tests/integration/cli-scaffold-constants.test.js
@@ -1,0 +1,22 @@
+/* eslint-env mocha */
+/* global describe, it */
+"use strict";
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execFileSync } = require('child_process');
+
+describe('CLI scaffold', function () {
+  it('creates an external constants package skeleton', function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-scaf-'));
+    const cliPath = path.resolve(__dirname, '..', '..', 'bin', 'cli.js');
+    const env = { ...process.env, FORCE_AI_CONFIG: '1', FORCE_ESLINT_CONFIG: '1', SKIP_AI_REQUIREMENTS: '1', NODE_ENV: 'test' };
+    execFileSync('node', [cliPath, 'scaffold', 'my-domain', '--dir=./pkg'], { cwd: tmp, env, stdio: 'pipe' });
+    const idx = fs.readFileSync(path.join(tmp, 'pkg', 'index.js'), 'utf8');
+    assert.match(idx, /domain: 'my-domain'/);
+    const pkg = JSON.parse(fs.readFileSync(path.join(tmp, 'pkg', 'package.json'), 'utf8'));
+    assert.strictEqual(pkg.main, 'index.js');
+  });
+});


### PR DESCRIPTION
Examples + scaffolder for external constants (#64)

- CLI: `scaffold <domain> [--dir=path]` to create an external constants package skeleton (index.js, package.json, README, test stub)
- Examples: added `examples/external/medical` and `examples/external/automotive` sample packages
- Tests: integration test for scaffolder

Complements discovery + rules integration; helps ecosystem/bootstrap community packages.

Refs: #64, PRs #67, #68, #70, #71