### PR TITLE
refactor(utils): extract version/requirements (+ file-writer), wire CLI to utils (Phase 1)

### DIFF
--- a/lib/utils/file-writer.js
+++ b/lib/utils/file-writer.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const fs = require('fs');
+const path = require('path');
+
+function writeFile(cwd, relPath, content, options = {}) {
+  const full = path.join(cwd, relPath);
+  if (fs.existsSync(full) && !options.overwrite) {
+    throw new Error(`File ${relPath} already exists`);
+  }
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf8');
+  return full;
+}
+
+function writeFiles(cwd, files) {
+  const results = [];
+  for (const f of files) {
+    try {
+      writeFile(cwd, f.path, f.content, { overwrite: f.overwrite });
+      results.push({ path: f.path, status: 'written' });
+    } catch (err) {
+      results.push({ path: f.path, status: 'error', error: err && err.message });
+    }
+  }
+  return results;
+}
+
+function readFile(cwd, relPath) {
+  const full = path.join(cwd, relPath);
+  if (!fs.existsSync(full)) return null;
+  return fs.readFileSync(full, 'utf8');
+}
+
+function readJsonFile(cwd, relPath) {
+  const txt = readFile(cwd, relPath);
+  if (txt == null) return null;
+  try {
+    return JSON.parse(txt);
+  } catch (err) {
+    throw new Error(`Invalid JSON in ${relPath}: ${err && err.message}`);
+  }
+}
+
+module.exports = {
+  writeFile,
+  writeFiles,
+  readFile,
+  readJsonFile
+};

--- a/lib/utils/requirements.js
+++ b/lib/utils/requirements.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const { gte, resolvePkgVersion } = require('./version');
+
+function checkRequirements(cwd, opts = { requireEslint: true }) {
+  if (process.env.SKIP_AI_REQUIREMENTS || process.env.NODE_ENV === 'test') return true;
+  let ok = true;
+  const nodeVer = process.versions.node;
+  if (!gte(nodeVer, '18.0.0')) {
+    console.error(`❌ Node.js 18+ required. You have ${nodeVer}. Install Node 18+ (recommended 20+).`);
+    ok = false;
+  } else {
+    console.log(`✅ Node.js ${nodeVer}`);
+  }
+  if (opts.requireEslint) {
+    const eslintVer = resolvePkgVersion('eslint', cwd);
+    if (!eslintVer || !gte(eslintVer, '9.0.0')) {
+      console.error(`❌ ESLint 9+ required. Your project: ${eslintVer || 'not installed'}.`);
+      console.error(`   Upgrade: npm install eslint@^9.0.0`);
+      ok = false;
+    } else {
+      console.log(`✅ ESLint ${eslintVer}`);
+    }
+  }
+  const reactVer = resolvePkgVersion('react', cwd);
+  if (reactVer && !gte(reactVer, '18.0.0')) {
+    console.warn(`⚠️ React 18+ recommended. Detected ${reactVer}.`);
+  }
+  const vueVer = resolvePkgVersion('vue', cwd);
+  if (vueVer && !gte(vueVer, '3.0.0')) {
+    console.warn(`⚠️ Vue 3+ recommended. Detected ${vueVer}.`);
+  }
+  const nextVer = resolvePkgVersion('next', cwd);
+  if (nextVer && !gte(nextVer, '13.0.0')) {
+    console.warn(`⚠️ Next.js 13+ recommended. Detected ${nextVer}.`);
+  }
+  return ok;
+}
+
+module.exports = {
+  checkRequirements
+};

--- a/lib/utils/version.js
+++ b/lib/utils/version.js
@@ -1,0 +1,25 @@
+"use strict";
+
+function gte(a, b) {
+  const pa = String(a).split('.').map(Number);
+  const pb = String(b).split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return true;
+    if ((pa[i] || 0) < (pb[i] || 0)) return false;
+  }
+  return true;
+}
+
+function resolvePkgVersion(name, cwd) {
+  try {
+    const pkg = require(require.resolve(`${name}/package.json`, { paths: [cwd] }));
+    return pkg.version || null;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = {
+  gte,
+  resolvePkgVersion
+};


### PR DESCRIPTION
Issue #76 Phase 1 (utils extraction)

- Extracted utils:
  - lib/utils/version.js (gte, resolvePkgVersion)
  - lib/utils/requirements.js (checkRequirements, test/CI skip preserved)
  - lib/utils/file-writer.js (writeFiles/writeFile/readFile/readJsonFile) — not yet wired into CLI
- Wired CLI to requirements util; behavior unchanged
- Restored learn routing after refactor; all integration tests still green

Next phases (separate PRs):
- Phase 2: generators extraction (coding-guide-json/md, agents, cursor, eslint)
- Phase 3: commands split (init/learn/scaffold) with thin CLI router

Refs: #76