### PR TITLE
feat(learn): interactive reconciliation + per-item review (implements #69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ npm install eslint-plugin-ai-code-snifftest --save-dev
 
 ## Usage
 
+See docs/learn.md for the Learn workflow (reconciliation, interactive review, fingerprint).
+
 In your [configuration file](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file), import the plugin `eslint-plugin-ai-code-snifftest` and add `ai-code-snifftest` to the `plugins` key:
 
 ```js

--- a/docs/README-START-HERE.md
+++ b/docs/README-START-HERE.md
@@ -262,6 +262,7 @@ npm run lint:fix      # Auto-fix linting issues
 - `README.md` - Main documentation
 
 ### Resources
+- Learn workflow: see docs/learn.md
 - Full GitHub Issue: 1,257 lines of detailed planning
 - ESLint Docs: https://eslint.org/docs/latest/extend/plugins
 - AST Explorer: https://astexplorer.net/

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -1,0 +1,40 @@
+# Learn workflow
+
+Adds a reconciliation step that:
+- Extracts current patterns (naming, constants, generics)
+- Compares to sane defaults
+- Reconciles to aligned settings and domain-aware constants
+- Supports interactive, strict, and permissive modes
+
+Usage:
+
+```
+eslint-plugin-ai-code-snifftest learn [--strict|--permissive|--interactive] [--sample=N] [--no-cache] [--apply] [--fingerprint]
+```
+
+Modes:
+- strict: enforce sane defaults; do not adopt weak local patterns
+- adaptive (default): adopt clear majorities; fall back to sane defaults
+- permissive: report current state without changing config; writes .ai-learn-report.json when --apply
+
+Interactive per-item review:
+- Naming style and boolean prefixes (inline edit)
+- Constants: [add] to fingerprint, [rename], [map] value→domain (updates constantResolution), [skip]
+- Writes .ai-constants/project-fingerprint.js when selected
+
+Fingerprint consumption:
+- `init` will auto-merge `.ai-constants/project-fingerprint.js` into `.ai-coding-guide.json`:
+  - Adds mapped domains to domains.additional
+  - Seeds constantResolution { "<value>": "<domain>" }
+
+Flags:
+- --sample: limit files scanned (sampling)
+- --no-cache: skip .ai-learn-cache.json (default uses cache)
+- --apply: write config (strict/adaptive) or report (permissive)
+- --fingerprint: write fingerprint from top suggestions (non-interactive)
+
+Key features:
+- Sampling and caching for fast scans (.ai-learn-cache.json)
+- Domain-aware constant name suggestions via builtin constants library
+- Per-item interactive review to apply config changes and optionally generate .ai-constants/project-fingerprint.js
+- Quality score with breakdown and warnings

--- a/lib/scanner/extract.js
+++ b/lib/scanner/extract.js
@@ -1,0 +1,171 @@
+"use strict";
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_IGNORE_DIRS = new Set(['node_modules', '.git', 'dist', 'build', 'coverage', '.next', '.cache']);
+
+function listFiles(root, exts, maxFiles) {
+  const out = [];
+  function walk(dir) {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { /* ignore */ return; }
+    for (const ent of entries) {
+      if (ent.name.startsWith('.')) {
+        // allow .ai-* files but skip hidden dirs by default
+        if (ent.isDirectory() && ent.name !== '.ai-constants') continue;
+      }
+      if (ent.isDirectory()) {
+        if (DEFAULT_IGNORE_DIRS.has(ent.name)) continue;
+        walk(path.join(dir, ent.name));
+        if (maxFiles && out.length >= maxFiles) return;
+      } else {
+        const fp = path.join(dir, ent.name);
+        const ext = path.extname(ent.name).toLowerCase();
+        if (!exts.length || exts.includes(ext)) {
+          out.push(fp);
+        }
+        if (maxFiles && out.length >= maxFiles) return;
+      }
+    }
+  }
+  walk(root);
+  return out;
+}
+
+function tokenizeNamesFromSource(src) {
+  const names = [];
+  try {
+    const declRe = /(const|let|var|function)\s+([A-Za-z_$][A-Za-z0-9_$]*)/g;
+    let m;
+    while ((m = declRe.exec(src))) {
+      names.push(m[2]);
+    }
+    // capture object properties as names too (heuristic)
+    const propRe = /([A-Za-z_$][A-Za-z0-9_$]*)\s*:/g;
+    while ((m = propRe.exec(src))) {
+      names.push(m[1]);
+    }
+  } catch {
+    // ignore parse heuristics errors
+  }
+  return names;
+}
+
+function classifyCasing(name) {
+  if (!name) return 'other';
+  if (/^[A-Z0-9_]+$/.test(name) && /_/.test(name)) return 'UPPER_SNAKE_CASE';
+  if (/^[a-z][A-Za-z0-9]*$/.test(name) && /[A-Z]/.test(name)) return 'camelCase';
+  if (/^[a-z0-9]+(_[a-z0-9]+)+$/.test(name)) return 'snake_case';
+  if (/^[A-Z][A-Za-z0-9]*$/.test(name)) return 'PascalCase';
+  return 'other';
+}
+
+function booleanPrefix(name) {
+  const prefixes = ['is','has','should','can','did','will','was','were'];
+  for (const p of prefixes) {
+    if (name && name.startsWith(p) && name.length > p.length && /[A-Z_]/.test(name[p.length])) return p;
+  }
+  return null;
+}
+
+function extractNumerics(src) {
+  const out = [];
+  const numRe = /(?<![A-Za-z0-9_.])(?:\d+\.\d+|\d+)(?:[eE][+-]?\d+)?/g;
+  let m;
+  while ((m = numRe.exec(src))) {
+    const raw = m[0];
+    const v = Number(raw);
+    if (!Number.isFinite(v)) continue;
+    out.push(v);
+  }
+  return out;
+}
+
+function loadCache(cachePath) {
+  try { return JSON.parse(fs.readFileSync(cachePath, 'utf8')); } catch { return { version: 1, files: {} }; }
+}
+
+function saveCache(cachePath, cache) {
+  try { fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2) + '\n'); } catch { /* ignore cache write */ }
+}
+
+function summarizeFileContent(src) {
+  const names = tokenizeNamesFromSource(src);
+  const casing = { camelCase: 0, snake_case: 0, PascalCase: 0, UPPER_SNAKE_CASE: 0, other: 0 };
+  const boolDist = {};
+  let withPrefix = 0;
+  let without = 0;
+  const genericList = ['data','result','value','info','item','object','obj','arr','array','list','tmp','temp','str','num','bool','flag','state'];
+  const genericNames = {};
+  for (const n of names) {
+    const c = classifyCasing(n);
+    casing[c] = (casing[c] || 0) + 1;
+    const bp = booleanPrefix(n);
+    if (bp) { withPrefix++; boolDist[bp] = (boolDist[bp] || 0) + 1; } else { without++; }
+    if (genericList.includes(n)) genericNames[n] = (genericNames[n] || 0) + 1;
+  }
+  const nums = extractNumerics(src);
+  const constCounts = {};
+  for (const v of nums) constCounts[v] = (constCounts[v] || 0) + 1;
+  const constants = Object.entries(constCounts).map(([value, count]) => ({ value: Number(value), count }));
+  return {
+    constants,
+    naming: {
+      casing,
+      booleanPrefixes: {
+        withPrefix,
+        without,
+        distribution: boolDist,
+        common: Object.keys(boolDist).sort((a,b)=> (boolDist[b]-boolDist[a]))
+      }
+    },
+    genericNames
+  };
+}
+
+function aggregateSummaries(summaries) {
+  const out = { constants: [], naming: { casing: {}, booleanPrefixes: { withPrefix: 0, without: 0, common: [], distribution: {} } }, genericNames: {} };
+  const constMap = new Map();
+  for (const s of summaries) {
+    for (const [k,v] of Object.entries(s.naming.casing || {})) out.naming.casing[k] = (out.naming.casing[k] || 0) + v;
+    out.naming.booleanPrefixes.withPrefix += s.naming.booleanPrefixes.withPrefix || 0;
+    out.naming.booleanPrefixes.without += s.naming.booleanPrefixes.without || 0;
+    for (const [k,v] of Object.entries(s.naming.booleanPrefixes.distribution || {})) out.naming.booleanPrefixes.distribution[k] = (out.naming.booleanPrefixes.distribution[k] || 0) + v;
+    for (const [k,v] of Object.entries(s.genericNames || {})) out.genericNames[k] = (out.genericNames[k] || 0) + v;
+    for (const c of s.constants || []) constMap.set(c.value, (constMap.get(c.value) || 0) + c.count);
+  }
+  out.constants = Array.from(constMap.entries()).map(([value, count]) => ({ value, count })).sort((a,b)=>b.count-a.count);
+  out.naming.booleanPrefixes.common = Object.keys(out.naming.booleanPrefixes.distribution).sort((a,b)=> (out.naming.booleanPrefixes.distribution[b]-out.naming.booleanPrefixes.distribution[a]));
+  // Convert to issue-style findings with confidence
+  const totalConst = out.constants.reduce((acc,c)=>acc+c.count,0) || 1;
+  out.constants = out.constants.map(c => ({ value: Number(c.value), name: null, confidence: Math.min(1, c.count / Math.max(3, totalConst)) }));
+  return out;
+}
+
+function scanProject(cwd, options) {
+  const opts = Object.assign({ sample: 400, useCache: true, cachePath: path.join(cwd, '.ai-learn-cache.json') }, options || {});
+  const files = listFiles(cwd, ['.js','.cjs','.mjs'], opts.sample);
+  const cache = opts.useCache ? loadCache(opts.cachePath) : { version: 1, files: {} };
+  const summaries = [];
+  for (const fp of files) {
+    let st; try { st = fs.statSync(fp); } catch { continue; }
+    const prev = cache.files[fp];
+    if (prev && prev.mtimeMs === st.mtimeMs) {
+      summaries.push(prev.summary);
+      continue;
+    }
+    let src; try { src = fs.readFileSync(fp, 'utf8'); } catch { continue; }
+    const summary = summarizeFileContent(src);
+    summaries.push(summary);
+    cache.files[fp] = { mtimeMs: st.mtimeMs, summary };
+  }
+  if (opts.useCache) saveCache(opts.cachePath, cache);
+  return aggregateSummaries(summaries);
+}
+
+module.exports = {
+  scanProject,
+  summarizeFileContent,
+  aggregateSummaries
+};

--- a/lib/scanner/reconcile.js
+++ b/lib/scanner/reconcile.js
@@ -1,0 +1,185 @@
+"use strict";
+
+
+const constantsLib = (()=>{ try { return require('../constants'); } catch { return null; }})();
+
+const DEFAULT_SANITY = Object.freeze({
+  naming: {
+    style: 'camelCase',
+    constants: 'UPPER_SNAKE_CASE',
+    booleanPrefix: ['is','has','should','can']
+  },
+  minimumConfidence: 0.7,
+  minimumMatch: 0.6
+});
+
+function bestNamingStyle(casingCounts) {
+  let best = { style: 'camelCase', count: -1 };
+  for (const [style, count] of Object.entries(casingCounts || {})) {
+    if (count > best.count && style !== 'other') best = { style, count };
+  }
+  return best.style;
+}
+
+function reconcileNaming(found, sane, mode) {
+  const casing = (found && found.casing) || {};
+  const total = Object.values(casing).reduce((a,b)=>a+b,0) || 1;
+  const best = bestNamingStyle(casing);
+  const majority = (casing[best] || 0) / total;
+  const result = { style: sane.naming.style, booleanPrefix: sane.naming.booleanPrefix.slice() };
+  const warnings = [];
+  if (mode === 'strict') {
+    result.style = sane.naming.style;
+  } else if (mode === 'permissive') {
+    // Prefer current majority regardless of threshold
+    result.style = best || sane.naming.style;
+  } else {
+    if (majority >= (sane.minimumMatch || 0.6)) {
+      result.style = best;
+    } else {
+      warnings.push(`Weak naming majority (${Math.round(majority*100)}%) → using sane default '${sane.naming.style}'`);
+    }
+  }
+  // boolean prefixes: keep sane list but ensure the most common in found are included
+  const dist = (found.booleanPrefixes && found.booleanPrefixes.distribution) || {};
+  const common = Object.keys(dist).sort((a,b)=> (dist[b]-dist[a])).slice(0,4);
+  for (const p of common) if (!result.booleanPrefix.includes(p)) result.booleanPrefix.push(p);
+  if (mode === 'strict') {
+    // reset to sane-only list in strict
+    result.booleanPrefix = sane.naming.booleanPrefix.slice();
+  }
+  return { result, warnings };
+}
+
+function findConstantMeta(value) {
+  if (!constantsLib || !constantsLib.DOMAINS) return null;
+  for (const [domain, mod] of Object.entries(constantsLib.DOMAINS)) {
+    const arr = Array.isArray(mod.constantMeta) ? mod.constantMeta : [];
+    for (const m of arr) {
+      if (typeof m.value === 'number' && Math.abs(m.value - value) <= 1e-9) {
+        return { domain, name: m.name, description: m.description };
+      }
+    }
+  }
+  // fallback: try bare constants list to get domain only
+  const dom = constantsLib.getDomainForValue ? constantsLib.getDomainForValue(value) : null;
+  if (dom) return { domain: dom, name: null, description: null };
+  return null;
+}
+
+function reconcileConstants(found, sane, options) {
+  const out = [];
+  const warnings = [];
+  const domainHits = [];
+  const minConf = sane.minimumConfidence || 0.7;
+  const cfg = (options && options.config) || { domainPriority: [], constantResolution: {} };
+  for (const c of (found || [])) {
+    if (c.confidence < minConf) continue;
+    const forceDomain = cfg.constantResolution && cfg.constantResolution[String(c.value)];
+    const meta = findConstantMeta(c.value);
+    let domain = forceDomain || (meta && meta.domain) || null;
+    // prefer configured domainPriority when multiple plausible domains (not fully detectable here)
+    if (!domain && constantsLib && constantsLib.getDomainForValue) {
+      domain = constantsLib.getDomainForValue(c.value);
+    }
+    let suggestedName = (meta && meta.name) || null;
+    if (!suggestedName && typeof c.value === 'number') {
+      // generic name from domain
+      if (domain === 'astronomy' && Math.abs(c.value - 365.25) <= 1e-9) suggestedName = 'TROPICAL_YEAR_DAYS';
+      else if (domain === 'time' && Math.abs(c.value - 86400) <= 1e-9) suggestedName = 'SECONDS_PER_DAY';
+      else if (domain === 'time' && Math.abs(c.value - 1000) <= 1e-9) suggestedName = 'MS_PER_SECOND';
+    }
+    if (domain) domainHits.push(domain);
+    out.push({ value: c.value, confidence: c.confidence, domain, suggestedName });
+  }
+  // domain summary
+  const domCount = domainHits.reduce((acc,d)=>{ acc[d]=(acc[d]||0)+1; return acc; },{});
+  return { result: out, warnings, domainSummary: domCount };
+}
+
+function reconcileAntiPatterns(found, mode) {
+  const out = { forbiddenNames: [] };
+  const warnings = [];
+  const entries = Object.entries(found || {}).sort((a,b)=> b[1]-a[1]);
+  const thr = mode === 'permissive' ? 5 : 3;
+  for (const [name, count] of entries.slice(0, 10)) {
+    if (count >= thr) out.forbiddenNames.push(name);
+  }
+  if (!out.forbiddenNames.length) warnings.push('No strong generic names found to forbid.');
+  return { result: out, warnings };
+}
+
+function computeQualityScore(findings, sane) {
+  const casing = findings.naming && findings.naming.casing || {};
+  const total = Object.values(casing).reduce((a,b)=>a+b,0) || 1;
+  const best = bestNamingStyle(casing);
+  const majority = (casing[best] || 0) / total;
+  const namingScore = Math.round(Math.min(1, Math.max(0, (majority - 0.4) / 0.6)) * 100);
+  const bool = findings.naming && findings.naming.booleanPrefixes || { withPrefix: 0, without: 0 };
+  const boolScore = Math.round(Math.min(1, (bool.withPrefix + 1) / (bool.withPrefix + bool.without + 1)) * 100);
+  const genTotal = Object.values(findings.genericNames || {}).reduce((a,b)=>a+b,0);
+  const genScore = Math.round(100 - Math.min(100, genTotal));
+  const constHigh = (findings.constants || []).filter(c=> c.confidence >= (sane.minimumConfidence || 0.7)).length;
+  const constScore = Math.min(100, 50 + constHigh * 10);
+  const overall = Math.round((namingScore*0.3 + boolScore*0.2 + genScore*0.2 + constScore*0.3));
+  return { overall, breakdown: { naming: namingScore, booleanPrefixes: boolScore, genericNames: genScore, constants: constScore }, notes: [] };
+}
+
+function reconcile(findings, sanityRules, options) {
+  const sane = Object.assign({}, DEFAULT_SANITY, sanityRules || {});
+  const warnings = [];
+  const recommendations = [];
+  const conflicts = [];
+
+  const mode = (options && options.mode) || 'adaptive';
+  const namingR = reconcileNaming(findings.naming || {}, sane, mode);
+  warnings.push(...namingR.warnings);
+
+  const constR = reconcileConstants(findings.constants || [], sane, options);
+  warnings.push(...constR.warnings);
+
+  const antiR = reconcileAntiPatterns(findings.genericNames || {}, mode);
+  warnings.push(...(antiR.warnings||[]));
+
+  const score = computeQualityScore(findings, sane);
+
+  const result = {
+    naming: namingR.result,
+    antiPatterns: antiR.result,
+    constantResolution: (options && options.config && options.config.constantResolution) || {},
+  };
+
+  return {
+    domain: { constants: constR.result, summary: constR.domainSummary },
+    result,
+    warnings,
+    recommendations,
+    conflicts,
+    score
+  };
+}
+
+function generateDomain(result) {
+  const items = (result && result.constants) || [];
+  const lines = [
+    "// Generated by 'learn' reconciliation",
+    "'use strict';",
+    'module.exports = {',
+    '  constants: [',
+    ...items.map(c => `    { value: ${c.value}, name: ${c.suggestedName ? `'${c.suggestedName}'` : 'null'}, domain: ${c.domain ? `'${c.domain}'` : 'null'} },`),
+    '  ]',
+    '};',
+    ''
+  ];
+  return lines.join('\n');
+}
+
+module.exports = {
+  DEFAULT_SANITY: DEFAULT_SANITY,
+  reconcile,
+  reconcileNaming,
+  reconcileConstants,
+  reconcileAntiPatterns,
+  computeQualityScore,
+  generateDomain
+};

--- a/tests/integration/cli-init-fingerprint.test.js
+++ b/tests/integration/cli-init-fingerprint.test.js
@@ -1,0 +1,30 @@
+/* eslint-env mocha */
+/* global describe, it */
+"use strict";
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+describe('CLI init consumes fingerprint', function () {
+  it('merges .ai-constants/project-fingerprint.js into config', function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-init-fp-'));
+    const dir = path.join(tmp, '.ai-constants');
+    fs.mkdirSync(dir, { recursive: true });
+    const fpFile = path.join(dir, 'project-fingerprint.js');
+    fs.writeFileSync(fpFile, `module.exports = { constants: [ { value: 365.25, name: 'TROPICAL_YEAR_DAYS', domain: 'astronomy' } ] };\n`);
+
+    const cliPath = path.resolve(__dirname, '..', '..', 'bin', 'cli.js');
+    const env = { ...process.env, SKIP_AI_REQUIREMENTS: '1', FORCE_AI_CONFIG: '1' };
+    execFileSync('node', [cliPath, 'init', '--primary=general'], { cwd: tmp, env, stdio: 'pipe' });
+
+    const cfgPath = path.join(tmp, '.ai-coding-guide.json');
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    assert.strictEqual(cfg.constantResolution['365.25'], 'astronomy');
+    // fingerprint domain should be added to additional domains
+    assert.ok(Array.isArray(cfg.domains.additional));
+    assert.ok(cfg.domains.additional.includes('astronomy'));
+  });
+});

--- a/tests/integration/cli-learn-apply.test.js
+++ b/tests/integration/cli-learn-apply.test.js
@@ -1,0 +1,57 @@
+/* eslint-env mocha */
+/* global describe, it */
+"use strict";
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+function writeFile(dir, rel, content) {
+  const full = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf8');
+}
+
+function runCliLearn(tmpDir, args = []) {
+  const cliPath = path.resolve(__dirname, '..', '..', 'bin', 'cli.js');
+  const env = { ...process.env, SKIP_AI_REQUIREMENTS: '1' };
+  execFileSync('node', [cliPath, 'learn', '--sample=50', '--no-cache', '--apply', ...args], {
+    cwd: tmpDir,
+    env,
+    stdio: 'pipe'
+  });
+}
+
+describe('CLI learn (non-interactive)', function () {
+  it('applies adaptive changes to .ai-coding-guide.json', function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-learn-'));
+    writeFile(tmp, 'src/a.js', `
+      const isReady = true; const hasValue = false;
+      const fooBar = 1; const data = 0; const result = 1; const data2 = 2; const data3 = 3;
+      function days() { return 365.25; }
+    `);
+    runCliLearn(tmp, []);
+    const cfgPath = path.join(tmp, '.ai-coding-guide.json');
+    assert.ok(fs.existsSync(cfgPath));
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    assert.ok(cfg.naming && cfg.naming.style); // naming recorded
+  });
+
+  it('strict mode updates config; permissive writes report only', function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-learn-'));
+    writeFile(tmp, 'src/b.js', `const snake_case = 1; const data = 0; const data = 1; const data = 2;`);
+    runCliLearn(tmp, ['--strict']);
+    const cfgPath = path.join(tmp, '.ai-coding-guide.json');
+    assert.ok(fs.existsSync(cfgPath));
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    assert.strictEqual(cfg.naming.style, 'camelCase');
+
+    const tmp2 = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-learn-'));
+    writeFile(tmp2, 'src/c.js', `const snake_case = 1;`);
+    runCliLearn(tmp2, ['--permissive']);
+    const reportPath = path.join(tmp2, '.ai-learn-report.json');
+    assert.ok(fs.existsSync(reportPath));
+  });
+});

--- a/tests/lib/scanner/extract-cache.test.js
+++ b/tests/lib/scanner/extract-cache.test.js
@@ -1,0 +1,32 @@
+/* eslint-env mocha */
+/* global describe, it */
+"use strict";
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { scanProject } = require('../../../lib/scanner/extract');
+
+function writeFile(dir, rel, content) {
+  const full = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content, 'utf8');
+}
+
+describe('scanner/extract cache & sampling', function() {
+  it('writes cache file and reuses it on second run', function() {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'scan-'));
+    writeFile(tmp, 'a.js', 'const x = 1;');
+    writeFile(tmp, 'b.js', 'const y = 2;');
+    const cachePath = path.join(tmp, '.ai-learn-cache.json');
+    scanProject(tmp, { sample: 10, useCache: true, cachePath });
+    assert.ok(fs.existsSync(cachePath));
+    const before = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    assert.ok(before.files && Object.keys(before.files).length >= 2);
+    const second = scanProject(tmp, { sample: 10, useCache: true, cachePath });
+    // findings should be stable and cache should still exist
+    assert.ok(second && second.naming && second.constants);
+  });
+});

--- a/tests/lib/scanner/reconcile.test.js
+++ b/tests/lib/scanner/reconcile.test.js
@@ -1,0 +1,35 @@
+/* eslint-env mocha */
+/* global describe, it */
+"use strict";
+
+const assert = require('assert');
+
+const { summarizeFileContent } = require('../../../lib/scanner/extract');
+const { reconcile, DEFAULT_SANITY } = require('../../../lib/scanner/reconcile');
+
+describe('scanner/reconcile', function() {
+  it('summarizeFileContent extracts naming and constants', function() {
+    const src = `
+      const isReady = true; const hasValue = false;
+      const fooBar = 1; const SNAKE_NAME = 2; const snake_case = 3;
+      function doThing() { return 365.25 + 60; }
+      const data = 0; const result = 1;
+    `;
+    const sum = summarizeFileContent(src);
+    assert.ok(sum.naming && sum.naming.casing);
+    assert.ok(sum.constants.find(c => c.value === 365.25));
+    assert.ok(sum.naming.booleanPrefixes.withPrefix >= 2);
+  });
+
+  it('reconcile computes score and domain-aware constants', function() {
+    const findings = {
+      constants: [{ value: 365.25, confidence: 0.9 }, { value: 60, confidence: 0.9 }],
+      naming: { casing: { camelCase: 10, snake_case: 0, UPPER_SNAKE_CASE: 2, PascalCase: 0 }, booleanPrefixes: { withPrefix: 5, without: 1, distribution: { is:3, has:2 } } },
+      genericNames: { data: 5, result: 3 }
+    };
+    const rec = reconcile(findings, DEFAULT_SANITY, { config: { domainPriority: ['time','astronomy'], constantResolution: {} } });
+    assert.ok(rec.score && typeof rec.score.overall === 'number');
+    assert.ok(rec.domain.constants.length >= 1);
+    assert.ok(rec.result.naming.style);
+  });
+});


### PR DESCRIPTION
Implements the learn reconciliation layer with interactive per-item review (closes #69).

Highlights:
- New `learn` CLI command with modes: --strict, adaptive (default), --permissive
- Interactive per-item UI: select constants, rename, map value→domain, edit boolean prefixes
- Domain-aware constant naming via builtin constants library (constantMeta)
- Sampling and cache: .ai-learn-cache.json with --sample and --no-cache
- Fingerprint support: generate .ai-constants/project-fingerprint.js; `init` consumes it (seeds constantResolution, domains)
- Quality score with breakdown + warnings
- Docs: docs/learn.md; linked from README and README-START-HERE
- Tests: CLI and unit tests for learn, fingerprint, cache

Notes:
- Default behavior is adaptive; strict/permissive covered in docs
- Adds files under lib/scanner, updates bin/cli.js

Please review. Lint and tests pass locally.