### PR TITLE
refactor(phase2): extract helper utilities from bin/cli.js (Part of #89)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,6 +11,10 @@ const { writeAgentsMd } = require(path.join(__dirname, '..', 'lib', 'generators'
 const { writeCursorRules } = require(path.join(__dirname, '..', 'lib', 'generators', 'cursorrules'));
 const { writeEslintConfig } = require(path.join(__dirname, '..', 'lib', 'generators', 'eslint-config'));
 
+// Utilities
+const { suggestFor } = require(path.join(__dirname, '..', 'lib', 'utils', 'domain-suggestions'));
+const { ask } = require(path.join(__dirname, '..', 'lib', 'utils', 'readline-utils'));
+
 function parseArgs(argv) {
   // simple parse; supports flags like --foo or --foo=bar
   const out = { _: [] };
@@ -27,19 +31,6 @@ function parseArgs(argv) {
 }
 
 
-function suggestFor(primary) {
-  const map = {
-    astronomy: ['geometry','math','units'],
-    music: ['math','cs'],
-    physics: ['math','units','cs'],
-    finance: ['math','statistics']
-  };
-  return map[primary] || [];
-}
-
-function ask(rl, q) {
-  return new Promise((resolve) => rl.question(q, (ans) => resolve(ans)));
-}
 
 async function initInteractive(cwd, args) {
   const readline = require('readline');

--- a/lib/utils/domain-suggestions.js
+++ b/lib/utils/domain-suggestions.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function suggestFor(primary) {
+  const map = {
+    astronomy: ['geometry','math','units'],
+    music: ['math','cs'],
+    physics: ['math','units','cs'],
+    finance: ['math','statistics']
+  };
+  return map[primary] || [];
+}
+
+module.exports = { suggestFor };

--- a/lib/utils/readline-utils.js
+++ b/lib/utils/readline-utils.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function ask(rl, q) {
+  return new Promise((resolve) => rl.question(q, (ans) => resolve(ans)));
+}
+
+module.exports = { ask };


### PR DESCRIPTION
Part of #89 - Phase 2 of 6: Extract Helper Utilities

## Summary

Second PR in the 6-phase refactor to reduce bin/cli.js from 769 lines to ~40 lines.

## Changes

Extracted 2 helper utility functions to lib/utils/:
- suggestFor() → domain-suggestions.js (13 lines)
- ask() → readline-utils.js (7 lines)

## Progress

- bin/cli.js: 537 → 528 lines (-9 lines this phase)
- Total: 769 → 528 lines (-241 lines, -31% total reduction)
- All 554 tests passing ✅

## Architecture

These are pure utility functions with no side effects:
- suggestFor(): Returns suggested additional domains for a given primary domain
- ask(): Promise wrapper for readline.question()

## Remaining Phases

3. Extract config utilities (loadProjectConfigFile, deepMerge, etc.) → ~80 lines
4. Extract requirements/args (parseArgs, checkRequirements, etc.) → ~70 lines
5. Extract commands (init, learn, scaffold) → ~350 lines
6. Final thin router → ~40 lines target

Part of #89