### PR TITLE
refactor(phase4): extract requirements and args utilities (Part of #89)

### DIFF
--- a/lib/utils/args-parser.js
+++ b/lib/utils/args-parser.js
@@ -1,0 +1,18 @@
+'use strict';
+
+function parseArgs(argv) {
+  // simple parse; supports flags like --foo or --foo=bar
+  const out = { _: [] };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const [k, v] = a.replace(/^--/, '').split('=');
+      out[k] = v === undefined ? true : v;
+    } else {
+      out._.push(a);
+    }
+  }
+  return out;
+}
+
+module.exports = { parseArgs };

--- a/lib/utils/cli-help.js
+++ b/lib/utils/cli-help.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function usage() {
+  console.log(`Usage:
+  eslint-plugin-ai-code-snifftest init [--primary=<domain>] [--additional=a,b,c] [--minimumMatch=0.6] [--minimumConfidence=0.7]
+  eslint-plugin-ai-code-snifftest learn [--strict|--permissive|--interactive] [--sample=N] [--no-cache] [--apply] [--fingerprint] [--minimumMatch=0.6] [--minimumConfidence=0.7]
+  eslint-plugin-ai-code-snifftest scaffold <domain> [--dir=path]
+
+Examples:
+  eslint-plugin-ai-code-snifftest init --primary=astronomy --additional=geometry,math,units --minimumMatch=0.65
+  eslint-plugin-ai-code-snifftest learn --interactive --sample=300 --minimumConfidence=0.75
+  eslint-plugin-ai-code-snifftest scaffold medical --dir=./examples/external/medical
+`);
+}
+
+module.exports = { usage };

--- a/lib/utils/requirements.js
+++ b/lib/utils/requirements.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const { resolvePkgVersion, gte } = require('./version-utils');
+
+function checkRequirements(cwd) {
+  if (process.env.SKIP_AI_REQUIREMENTS || process.env.NODE_ENV === 'test') return true;
+  let ok = true;
+  const nodeVer = process.versions.node;
+  if (!gte(nodeVer, '18.0.0')) {
+    console.error(`❌ Node.js 18+ required. You have ${nodeVer}. Install Node 18+ (recommended 20+).`);
+    ok = false;
+  } else {
+    console.log(`✅ Node.js ${nodeVer}`);
+  }
+  const eslintVer = resolvePkgVersion('eslint', cwd);
+  if (!eslintVer || !gte(eslintVer, '9.0.0')) {
+    console.error(`❌ ESLint 9+ required. Your project: ${eslintVer || 'not installed'}.`);
+    console.error(`   Upgrade: npm install eslint@^9.0.0`);
+    ok = false;
+  } else {
+    console.log(`✅ ESLint ${eslintVer}`);
+  }
+  const reactVer = resolvePkgVersion('react', cwd);
+  if (reactVer && !gte(reactVer, '18.0.0')) {
+    console.warn(`⚠️ React 18+ recommended. Detected ${reactVer}.`);
+  }
+  const vueVer = resolvePkgVersion('vue', cwd);
+  if (vueVer && !gte(vueVer, '3.0.0')) {
+    console.warn(`⚠️ Vue 3+ recommended. Detected ${vueVer}.`);
+  }
+  const nextVer = resolvePkgVersion('next', cwd);
+  if (nextVer && !gte(nextVer, '13.0.0')) {
+    console.warn(`⚠️ Next.js 13+ recommended. Detected ${nextVer}.`);
+  }
+  return ok;
+}
+
+module.exports = { checkRequirements };

--- a/lib/utils/version-utils.js
+++ b/lib/utils/version-utils.js
@@ -1,0 +1,22 @@
+'use strict';
+
+function resolvePkgVersion(name, cwd) {
+  try {
+    const pkg = require(require.resolve(`${name}/package.json`, { paths: [cwd] }));
+    return pkg.version || null;
+  } catch {
+    return null;
+  }
+}
+
+function gte(a, b) {
+  const pa = String(a).split('.').map(Number);
+  const pb = String(b).split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return true;
+    if ((pa[i] || 0) < (pb[i] || 0)) return false;
+  }
+  return true;
+}
+
+module.exports = { resolvePkgVersion, gte };


### PR DESCRIPTION
Part of #89 - Phase 4 of 6: Extract Requirements & Args Utilities

## Summary

Fourth PR in the 6-phase refactor to reduce bin/cli.js from 769 lines to ~40 lines.

## Changes

Extracted utility functions:
- parseArgs() → lib/utils/args-parser.js (18 lines)
- usage() → lib/utils/cli-help.js (16 lines)
- resolvePkgVersion() + gte() → lib/utils/version-utils.js (22 lines)
- checkRequirements() → lib/utils/requirements.js (38 lines)

## Progress

- bin/cli.js: 473 → 407 lines (-66 lines this phase)
- Total: 769 → 407 lines (-362 lines, -47% total reduction)
- All 554 tests passing ✅

## Architecture

These utilities handle CLI bootstrap concerns:
- Args parsing: Simple flag/value parsing for CLI arguments
- Help text: Usage instructions and examples
- Version checks: Package version resolution and comparison
- Requirements: Node.js, ESLint, framework version validation

## Remaining Phases

5. Extract commands (init, learn, scaffold) → ~350 lines - THE BIG ONE
6. Final thin router → ~40 lines target

Part of #89