### PR TITLE
Complete fix for #114: Add integration test and fix array overwrite

### DIFF
--- a/lib/commands/init/index.js
+++ b/lib/commands/init/index.js
@@ -29,13 +29,13 @@ function initCommand(cwd, args) {
   const minimumConfidence = args.minimumConfidence ? parseFloat(args.minimumConfidence) : 0.7;
   
   // Create new config structure
+  // Note: Don't include antiPatterns here to preserve existing forbiddenNames from learn
   const newCfg = {
     domains: { primary, additional },
     domainPriority,
     constants: {},
     terms: { entities: [], properties: [], actions: [] },
     naming: { style: 'camelCase', booleanPrefix: ['is','has','should','can'], asyncPrefix: ['fetch','load','save'], pluralizeCollections: true },
-    antiPatterns: { forbiddenNames: [], forbiddenTerms: [] },
     minimumMatch,
     minimumConfidence,
     experimentalExternalConstants: external,
@@ -157,13 +157,13 @@ async function initInteractiveCommand(cwd, args) {
     const { json: existingCfg } = loadProjectConfigFile(cwd);
     
     // Create new config structure
+    // Note: Don't include antiPatterns here to preserve existing forbiddenNames from learn
     const newCfg = {
       domains: { primary, additional },
       domainPriority,
       constants: {},
       terms: { entities: [], properties: [], actions: [] },
-      naming: { style: 'camelCase', booleanPrefix: ['is','has','should','can'], asyncPrefix: ['fetch','load','save'], pluralizeCollections: true },
-      antiPatterns: { forbiddenNames: [], forbiddenTerms: [] }
+      naming: { style: 'camelCase', booleanPrefix: ['is','has','should','can'], asyncPrefix: ['fetch','load','save'], pluralizeCollections: true }
     };
     
     // Merge with existing config to preserve learn command data

--- a/tests/integration/cli-learn-init-flow.test.js
+++ b/tests/integration/cli-learn-init-flow.test.js
@@ -1,0 +1,77 @@
+/* eslint-env mocha */
+/* global describe, it */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+describe('CLI learn → init workflow', function () {
+  it('preserves forbiddenNames through learn → init', function () {
+    // Create temp directory
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'learn-init-'));
+    
+    const cliPath = path.resolve(__dirname, '..', '..', 'bin', 'cli.js');
+    const env = { ...process.env, SKIP_AI_REQUIREMENTS: '1', FORCE_AI_CONFIG: '1' };
+    const cfgPath = path.join(tmp, '.ai-coding-guide.json');
+    
+    // Step 1: Simulate what learn command would create
+    // Create a config file with forbidden names (as if learn had saved them)
+    const configWithForbiddenNames = {
+      domains: { primary: 'general', additional: [] },
+      domainPriority: ['general'],
+      constants: {},
+      terms: { entities: [], properties: [], actions: [] },
+      naming: {
+        style: 'camelCase',
+        booleanPrefix: ['is', 'has', 'should', 'can'],
+        asyncPrefix: ['fetch', 'load', 'save'],
+        pluralizeCollections: true
+      },
+      antiPatterns: {
+        forbiddenNames: ['data', 'result', 'temp', 'value', 'item'],
+        forbiddenTerms: []
+      },
+      minimumMatch: 0.6,
+      minimumConfidence: 0.7
+    };
+    
+    fs.writeFileSync(cfgPath, JSON.stringify(configWithForbiddenNames, null, 2));
+    
+    const cfgAfterLearn = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    const forbiddenNamesFromLearn = cfgAfterLearn.antiPatterns?.forbiddenNames || [];
+    
+    // Verify we have forbidden names to test with
+    assert.ok(forbiddenNamesFromLearn.length > 0, 
+      'Config should have forbidden names for testing');
+    
+    // Step 2: Run init (should merge with existing config, not overwrite)
+    execFileSync('node', [cliPath, 'init', '--primary=dev-tools', '--additional=cli'], {
+      cwd: tmp,
+      env,
+      stdio: 'pipe'
+    });
+    
+    // Step 3: Verify init preserved forbidden names from learn
+    const cfgAfterInit = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    const forbiddenNamesAfterInit = cfgAfterInit.antiPatterns?.forbiddenNames || [];
+    
+    // Assert: forbidden names should be preserved
+    assert.deepStrictEqual(
+      forbiddenNamesAfterInit.sort(),
+      forbiddenNamesFromLearn.sort(),
+      'Init should preserve forbiddenNames from learn command'
+    );
+    
+    // Also verify init added its domain settings
+    assert.strictEqual(cfgAfterInit.domains.primary, 'dev-tools',
+      'Init should set primary domain');
+    assert.ok(cfgAfterInit.domains.additional.includes('cli'),
+      'Init should add additional domains');
+    
+    // Cleanup
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Fixes #114 (Complete Fix)

## Summary

PR #115 was incomplete! It added `deepMerge()` to preserve existing config, but `deepMerge` **overwrites arrays**. This PR completes the fix and adds an integration test that catches the bug.

## The Real Bug

**PR #115 fix (incomplete):**
```javascript
const newCfg = {
  antiPatterns: { forbiddenNames: [], forbiddenTerms: [] }  // ❌ Empty array!
};
const cfg = deepMerge(existingCfg, newCfg);
```

**Problem:** `deepMerge()` in `lib/utils/project-config.js` line 39:
```javascript
if (v && typeof v === 'object' && !Array.isArray(v) && ...) {
  out[k] = deepMerge(base[k], v);  // Only for objects
} else {
  out[k] = v;  // Arrays just overwrite! ❌
}
```

When `newCfg` has `forbiddenNames: []`, the empty array **overwrites** the existing forbidden names from learn.

## Complete Fix

**Don't include `antiPatterns` in `newCfg` at all:**
```javascript
const newCfg = {
  domains: { primary, additional },
  // ... other fields
  // antiPatterns removed - let deepMerge preserve existing value
};
const cfg = deepMerge(existingCfg, newCfg);  // ✅ Preserves forbiddenNames
```

## Integration Test Added

`tests/integration/cli-learn-init-flow.test.js` - This test would have caught the bug:

1. Creates config with `forbiddenNames: ['data', 'result', 'temp', 'value', 'item']`
2. Runs `init --primary=dev-tools`
3. Verifies forbidden names are **preserved**
4. Before this fix: Test failed (empty array)
5. After this fix: Test passes ✅

## Testing

- ✅ All 555 tests passing
- ✅ New integration test validates learn → init workflow
- ✅ Existing init tests still pass (no regression)

## Changes

- `lib/commands/init/index.js`: Removed `antiPatterns` from `newCfg` (2 locations - interactive + non-interactive)
- `tests/integration/cli-learn-init-flow.test.js`: New integration test

## Why PR #115 Wasn't Enough

PR #115 correctly identified that init was overwriting config, but the `deepMerge()` implementation has a limitation: it doesn't deep-merge arrays. The test we added here proves the fix works end-to-end.
