### PR TITLE
feat: Enable architecture guardrails by default (#120)

### DIFF
--- a/lib/commands/init/index.js
+++ b/lib/commands/init/index.js
@@ -44,8 +44,9 @@ function initCommand(cwd, args) {
   
   // Merge with existing config to preserve learn command data
   const cfg = deepMerge(existingCfg, newCfg);
-  // Add architecture guardrails if --arch flag is set
-  if (args.arch || args.architecture) {
+  // Add architecture guardrails by default (disable with --no-arch or --arch=false)
+  const enableArch = !(args['no-arch'] === true || args.arch === false || args.arch === 'false');
+  if (enableArch) {
     const { DEFAULT_ARCHITECTURE } = require(path.join(__dirname, '..', '..', 'utils', 'arch-defaults'));
     cfg.architecture = JSON.parse(JSON.stringify(DEFAULT_ARCHITECTURE));
   }

--- a/tests/integration/cli-init-arch-guardrails.test.js
+++ b/tests/integration/cli-init-arch-guardrails.test.js
@@ -19,41 +19,54 @@ function runCliInit(tmpDir, args = []) {
 }
 
 describe('CLI init with architecture guardrails', function () {
-  it('does not include architecture in config when not enabled (default)', function () {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-arch-disabled-'));
+  it('includes architecture in config by default (new default behavior)', function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-arch-enabled-'));
     runCliInit(tmp);
     
     const cfgPath = path.join(tmp, '.ai-coding-guide.json');
     assert.ok(fs.existsSync(cfgPath), 'Config file should exist');
     
     const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
-    assert.strictEqual(cfg.architecture, undefined, 'Should not have architecture section by default');
+    assert.ok(cfg.architecture, 'Should have architecture section by default');
+    assert.ok(cfg.architecture.maxFileLength, 'Should have maxFileLength in architecture');
   });
 
-  it('generates ESLint config without architecture guardrails comment when not enabled', function () {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-arch-eslint-disabled-'));
+  it('generates ESLint config with architecture guardrails by default', function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-arch-eslint-enabled-'));
     runCliInit(tmp);
     
     const eslintPath = path.join(tmp, 'eslint.config.js');
     assert.ok(fs.existsSync(eslintPath), 'ESLint config should exist');
     
     const eslintContent = fs.readFileSync(eslintPath, 'utf8');
-    assert.ok(!eslintContent.includes('Architecture guardrails'), 'Should not have architecture guardrails comment');
-    // Note: ESLint config has some complexity rules by default, but not the architecture-specific ones
+    assert.ok(eslintContent.includes('Architecture guardrails'), 'Should have architecture guardrails comment');
+    assert.ok(eslintContent.includes("'max-lines'"), 'Should have max-lines rule');
   });
 
-  it('generates AGENTS.md without architecture section when not enabled', function () {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-arch-agents-disabled-'));
+  it('generates AGENTS.md with architecture section by default', function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-arch-agents-enabled-'));
     runCliInit(tmp, ['--agents']);
     
     const agentsPath = path.join(tmp, 'AGENTS.md');
-    if (fs.existsSync(agentsPath)) {
-      const content = fs.readFileSync(agentsPath, 'utf8');
-      assert.ok(!content.includes('Architecture Guidelines'), 'Should not have architecture section');
-    }
+    assert.ok(fs.existsSync(agentsPath), 'AGENTS.md should exist');
+    const content = fs.readFileSync(agentsPath, 'utf8');
+    assert.ok(content.includes('Architecture Guidelines'), 'Should have architecture section');
+  });
+
+  it('does not include architecture when --no-arch flag is used', function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-no-arch-'));
+    runCliInit(tmp, ['--no-arch']);
+    
+    const cfgPath = path.join(tmp, '.ai-coding-guide.json');
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    assert.strictEqual(cfg.architecture, undefined, 'Should not have architecture with --no-arch');
+    
+    const eslintPath = path.join(tmp, 'eslint.config.js');
+    const eslintContent = fs.readFileSync(eslintPath, 'utf8');
+    assert.ok(!eslintContent.includes('Architecture guardrails'), 'Should not have architecture guardrails with --no-arch');
+    assert.ok(!eslintContent.includes("'max-lines'"), 'Should not have max-lines rule with --no-arch');
   });
 });
 
-// Note: Testing with architecture enabled requires interactive mode
-// which is covered by manual testing. These tests verify the default
-// behavior (architecture disabled) works correctly.
+// Note: Architecture guardrails are now enabled by default.
+// Use --no-arch flag to disable them.


### PR DESCRIPTION
## Summary

Fixes #120 by making architecture guardrails (including file-level `max-lines` enforcement) enabled by default.

## Problem

During dogfood testing (Phase 7), we discovered that file length limits documented in AGENTS.md were **only enforced when using `--arch` flag**. This created UX confusion:
- AGENTS.md shows file limits table (CLI: 100, Commands: 150, etc.)
- Users didn't realize they needed `--arch` flag
- Without `--arch`, only function-level limits were enforced

## Solution

**Make `--arch` the default behavior:**
- Architecture guardrails now enabled by default
- Add `--no-arch` flag to disable if users want minimal config
- Update tests to reflect new default

## Changes

### 1. `lib/commands/init/index.js`
```javascript
// Before: opt-in with --arch flag
if (args.arch || args.architecture) {
  cfg.architecture = DEFAULT_ARCHITECTURE;
}

// After: opt-out with --no-arch flag
const enableArch = !(args['no-arch'] === true || args.arch === false || args.arch === 'false');
if (enableArch) {
  cfg.architecture = DEFAULT_ARCHITECTURE;
}
```

### 2. `tests/integration/cli-init-arch-guardrails.test.js`
- Updated 3 existing tests to expect architecture enabled by default
- Added new test for `--no-arch` flag
- All 556 tests passing ✅

## Breaking Change

⚠️ **BREAKING CHANGE**: Architecture guardrails are now enabled by default.

**Impact:**
- Users who previously ran `init` without `--arch` will now get file-level `max-lines` rules
- This may cause new ESLint violations in existing projects
- Users can opt-out with `--no-arch` flag

**Migration:**
```bash
# To get old behavior (no architecture rules)
init --primary=your-domain --no-arch
```

## Testing

All 556 tests passing ✅

## Benefits

✅ **Better DX** - Works as documented without extra flags
✅ **Alignment** - AGENTS.md promises match actual behavior  
✅ **Dogfood validated** - Addresses real UX confusion we found

Closes #120