### PR TITLE
feat: add max-depth exemption for test files

### DIFF
--- a/lib/generators/eslint-arch-config.js
+++ b/lib/generators/eslint-arch-config.js
@@ -81,7 +81,8 @@ function generateArchitectureRules(architecture) {
     rules: {
       'max-lines-per-function': 'off',
       'max-statements': 'off',
-      'complexity': 'off'
+      'complexity': 'off',
+      'max-depth': 'off'
     }
   });
 

--- a/tests/lib/generators/eslint-arch-config.test.js
+++ b/tests/lib/generators/eslint-arch-config.test.js
@@ -121,6 +121,7 @@ describe('eslint-arch-config generator', function () {
       assert.strictEqual(testOverride.rules['max-lines-per-function'], 'off');
       assert.strictEqual(testOverride.rules['max-statements'], 'off');
       assert.strictEqual(testOverride.rules['complexity'], 'off');
+      assert.strictEqual(testOverride.rules['max-depth'], 'off');
     });
   });
 


### PR DESCRIPTION
Fixes #119

## Changes
- Added `max-depth: off` to test file overrides in `lib/generators/eslint-arch-config.js`
- Updated test to verify the exemption

## Testing
- ✅ All 556 tests pass
- ✅ Test files show no complexity violations (max-lines-per-function, complexity, max-statements, max-depth)
- ✅ Source files still have all complexity rules enforced

## Impact
Test files are now properly exempt from all 4 complexity rules as documented in AGENTS.md.