### PR TITLE
docs: add architecture troubleshooting and ignore .ai-init-debug.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ dist/
 
 # Local ideation (not tracked)
 domain_ideas/
+
+# Init debug snapshot (created only when AI_DEBUG_INIT=1 or --debug)
+.ai-init-debug.json

--- a/README.md
+++ b/README.md
@@ -316,6 +316,28 @@ npm update eslint-plugin-ai-code-snifftest
 FORCE_ESLINT_CONFIG=1 npx eslint-plugin-ai-code-snifftest init
 ```
 
+### Architecture guardrails missing
+If `eslint.config.mjs` doesn’t include “Architecture guardrails” or test files aren’t exempted:
+
+1) Generate a debug snapshot
+```bash
+AI_DEBUG_INIT=1 npx eslint-plugin-ai-code-snifftest init --yes --eslint
+# or
+npx eslint-plugin-ai-code-snifftest init --yes --eslint --debug
+```
+
+2) Inspect `.ai-init-debug.json` in your project root. It includes:
+- args: parsed CLI flags (e.g., `--no-arch`, `--arch=false`, `--yes`, `--eslint`)
+- enableArch: whether architecture was enabled
+- cfgHasArchitecture: whether architecture config was added
+- files.eslintConfig: path to generated config
+- files.eslintHasGuardrails: whether guardrail rules were written
+- files.agentsHasArchitectureSection: whether `AGENTS.md` includes the section
+
+3) Share `.ai-init-debug.json` in your GitHub issue if you need help (it contains no secrets).
+
+Tip: Add `.ai-init-debug.json` to `.gitignore` (this repo does).
+
 ---
 
 ## Limitations


### PR DESCRIPTION
Adds a Troubleshooting section for architecture guardrails (debug snapshot via AI_DEBUG_INIT/--debug) and ignores .ai-init-debug.json in .gitignore.