### PR TITLE
docs: migration guide; setup quick start; learn post-generate test; deprecation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ See full command and flag reference in [docs/CLI.md](docs/CLI.md).
 
 ## Quick Start (2 Minutes)
 
-### Option 1: Analyze Your Code First (Recommended)
+### Option 0: One-Command Setup (Recommended)
+```bash
+npx eslint-plugin-ai-code-snifftest setup --yes
+```
+
+### Option 1: Analyze Your Code First
 ```bash
 # Step 1: Analyze your codebase
 npx eslint-plugin-ai-code-snifftest learn --interactive
@@ -148,6 +153,12 @@ We tested this tool on its own codebase during a refactoring effort.
 - Quote style violations: 204 (auto-fixed)
 
 See [DOGFOOD_RESULTS.md](./docs/DOGFOOD_RESULTS.md) for complete analysis.
+
+---
+
+## Migration Notes
+
+See docs/MIGRATION.md for changes in defaults and new commands.
 
 ---
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,38 @@
+# Migration Guide
+
+This document summarizes breaking/behavioral changes introduced across UX issue #127 phases.
+
+## vNext (Phase 2–3)
+
+### Defaults
+- `init` now generates AGENTS.md and eslint.config.mjs by default
+  - Use `--no-agents` to skip AGENTS.md
+  - Use `--no-eslint` to skip ESLint config
+- Architecture guardrails are enabled by default
+  - Disable with `--no-arch` or `--arch=false`
+- `.cursorrules` remains opt-in via `--cursor`
+
+### New Commands
+- `setup`: runs `learn` then `init`
+  - Interactive by default
+  - `--yes` runs learn(strict+apply) and init(defaults)
+  - `--skip-learn` to only run `init`
+
+### Learn Enhancements
+- Interactive `learn` offers to generate AGENTS.md and eslint.config.mjs at the end
+  - Default-on; honors `--no-agents` and `--no-eslint`
+  - Honors `--arch` / `--no-arch` by updating `.ai-coding-guide.json` first
+
+### Deprecations (soft)
+- `--agents` and `--eslint` are no longer required (defaults are on)
+  - Flags remain accepted for compatibility; a note is printed when used
+
+### Recommended Usage
+```bash
+# One-command setup
+npx eslint-plugin-ai-code-snifftest setup --yes
+
+# Or: learn first, then init
+npx eslint-plugin-ai-code-snifftest learn --interactive
+npx eslint-plugin-ai-code-snifftest init
+```

--- a/lib/commands/init/index.js
+++ b/lib/commands/init/index.js
@@ -70,6 +70,14 @@ function initCommand(cwd, args) {
   const shouldWriteAgents = disableAgents ? false : (explicitAgents === undefined ? true : explicitAgents);
   const shouldWriteEslint = disableEslint ? false : (explicitEslint === undefined ? true : explicitEslint);
 
+  // Informative note: --agents/--eslint are defaults now
+  if (args.agents && !disableAgents) {
+    console.log('Note: --agents is the default; this flag is no longer required.');
+  }
+  if (args.eslint && !disableEslint) {
+    console.log('Note: --eslint is the default; this flag is no longer required.');
+  }
+
   if (shouldWriteAgents) {
     writeAgentsMd(cwd, cfg);
     if (hasWarp) {

--- a/tests/integration/cli-learn-post-generate.test.js
+++ b/tests/integration/cli-learn-post-generate.test.js
@@ -1,0 +1,59 @@
+/* eslint-env mocha */
+/* global describe, it */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+function runInteractiveLearnAndGenerate(tmpDir, extraArgs = []) {
+  return new Promise((resolve, reject) => {
+    const cliPath = path.resolve(__dirname, '..', '..', 'bin', 'cli.js');
+    const env = { ...process.env, SKIP_AI_REQUIREMENTS: '1' };
+    const child = spawn('node', [cliPath, 'learn', '--interactive', '--sample=60', '--no-cache', ...extraArgs], {
+      cwd: tmpDir,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+
+    // Feed a bunch of newlines to accept defaults across prompts, including the new generate prompt
+    let remaining = 14;
+    const iv = setInterval(() => {
+      if (remaining <= 0) {
+        clearInterval(iv);
+        child.stdin.end();
+        return;
+      }
+      child.stdin.write('\n');
+      remaining -= 1;
+    }, 80);
+
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+
+    setTimeout(() => { try { child.kill(); } catch (e) { /* ignore */ } reject(new Error('timeout')); }, 30000);
+  });
+}
+
+describe('CLI learn interactive post-generation prompt', function () {
+  this.timeout(35000);
+
+  it('offers and generates AGENTS.md + ESLint when user accepts default', async function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-learn-gen-'));
+    // Create some basic JS files to ensure scanner finds content
+    fs.writeFileSync(path.join(tmp, 'index.js'), 'const x = 1; function f(){ return x; }\n');
+
+    const res = await runInteractiveLearnAndGenerate(tmp);
+    assert.strictEqual(res.code, 0, res.stderr);
+    assert.ok(fs.existsSync(path.join(tmp, '.ai-coding-guide.json')));
+    assert.ok(fs.existsSync(path.join(tmp, 'AGENTS.md')));
+    assert.ok(fs.existsSync(path.join(tmp, 'eslint.config.mjs')));
+  });
+});


### PR DESCRIPTION
Phase 3 of #127 – Polish: migration notes, quick start, and tests

What this includes
- docs/MIGRATION.md: changes to defaults (init), new setup command, learn post-prompt, soft deprecations
- README.md: Quick Start Option 0 (one-command `setup --yes`) and link to migration notes
- lib/commands/init/index.js: print informational note when using legacy flags `--agents` / `--eslint` (now defaults)
- tests/integration/cli-learn-post-generate.test.js: verifies interactive learn post-generation path

Validation
- All tests passing locally: 564 passing, 3 pending

Part of #127 – Phase 3
