### PR TITLE
fix(setup): persist architecture in JSON; fix AGENTS footer

### DIFF
--- a/.ai-coding-guide.json
+++ b/.ai-coding-guide.json
@@ -1,0 +1,46 @@
+{
+  "domain": "general",
+  "domains": {
+    "primary": "general",
+    "additional": []
+  },
+  "domainPriority": [],
+  "constantResolution": {},
+  "version": "1.0",
+  "constants": {},
+  "terms": {
+    "entities": [],
+    "properties": [],
+    "actions": []
+  },
+  "naming": {
+    "style": "camelCase",
+    "booleanPrefix": [
+      "is",
+      "has",
+      "should",
+      "can"
+    ],
+    "asyncPrefix": [
+      "fetch",
+      "load",
+      "save"
+    ],
+    "pluralizeCollections": true
+  },
+  "antiPatterns": {
+    "forbiddenNames": [
+      "value",
+      "data",
+      "result",
+      "tmp",
+      "arr",
+      "obj",
+      "bool",
+      "item"
+    ],
+    "forbiddenTerms": []
+  },
+  "experimentalExternalConstants": false,
+  "externalConstantsAllowlist": []
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,204 @@
+# AI Coding Rules
+
+**Project**: ESLint plugin
+**Domains**: general
+**Priority**: general
+**Tech Stack**: Node.js ^18.18.0 || ^20.9.0 || >=21.1.0, ESLint 9+
+
+---
+
+## Naming
+- Style: camelCase
+- Booleans: isX/hasX/shouldX/canX
+- Async: fetchX/loadX/saveX
+
+## Guidance
+- Use @domain/@domains annotations for ambiguous constants
+- Prefer constants/terms from active domains
+
+
+## Architecture Guidelines
+
+## File Organization
+
+**Pattern**: feature-based (group by feature, not type)
+
+**Example Structure**:
+```
+lib/
+  commands/           # Core commands
+    init/
+      index.js          # Orchestrator
+      config-builder.js # Business logic
+    validate/
+      index.js
+  generators/         # File generators
+  utils/              # Shared helpers
+  tests/              # Tests (co-located or here)
+```
+
+**Avoid (Type-based)**:
+```
+❌ lib/
+    controllers/        # Groups by layer
+    services/           # Hard to find features
+    models/
+    views/
+```
+
+## File Length Limits
+
+| File Type | Max Lines | Rationale |
+|-----------|-----------|-----------|
+| CLI entry | 100 | Routing only |
+| Commands  | 150 | Orchestration |
+| Utilities | 200 | Single purpose |
+| Generators| 250 | Template logic |
+| Components| 300 | UI complexity |
+| Tests     | ∞ | No limit |
+| Default   | 250 | General files |
+
+**Function Limits:**
+- Max length: 50 lines
+- Max complexity: 10
+- Max depth: 4
+- Max parameters: 4
+- Max statements: 30
+
+**Code Patterns:**
+- CLI style: orchestration-shell
+- Error handling: explicit
+- Async style: async-await
+
+
+## Code Patterns
+
+### CLI Style
+```javascript
+// ✅ Good: Orchestration shell
+async function main() {
+  const args = parseArgs(process.argv);
+  const command = commands[args._[0]];
+  await command(process.cwd(), args);
+}
+
+// ❌ Bad: Business logic in CLI
+async function main() {
+  // 200 lines of logic here
+}
+```
+
+### Error Handling
+```javascript
+// ✅ Explicit
+try {
+  await riskyOperation();
+} catch (err) {
+  console.error(`Failed: ${err.message}`);
+  process.exit(1);
+}
+
+// ❌ Silent
+try {
+  await riskyOperation();
+} catch {} // ❌ No error handling
+```
+
+### Async Style
+```javascript
+// ✅ async/await
+async function loadData() {
+  const data = await fetchData();
+  return process(data);
+}
+
+// ❌ Callbacks or raw promises
+function loadData(callback) {
+  fetchData().then(data => callback(null, data));
+}
+```
+
+## Import/Export Conventions
+
+**Current**: CommonJS (`require`/`module.exports`)
+
+```javascript
+// ✅ Named imports (CommonJS)
+const { foo, bar } = require('./utils');
+
+// ✅ Module exports
+module.exports = { foo, bar };
+
+// ✅ Single export (entry points)
+module.exports = main;
+function main() {}
+
+// ✅ Alphabetize imports
+const { a, b, c } = require('./foo');
+const { x, y, z } = require('./bar');
+
+// ❌ Avoid mixing module systems
+const foo = require('./foo');
+export const bar = 'bar';  // ❌ Don't mix CommonJS + ES modules
+```
+
+**Note**: Planning migration to ES modules (see issue #112)
+
+## Test Conventions
+
+**Location**: Co-locate or `tests/` directory
+```
+foo.js
+foo.test.js  ✅
+```
+
+**Naming**:
+```javascript
+// ✅ Descriptive
+test('loads config from .ai-coding-guide.json', () => {});
+
+// ❌ Vague
+test('it works', () => {});
+```
+
+**Note**: Test files exempt from line/complexity limits
+
+## Documentation
+
+**Required**:
+- JSDoc for public functions
+- README.md in feature directories
+- Examples for complex logic
+
+**Example**:
+```javascript
+/**
+ * Generate ESLint config from domain configuration
+ * @param {Object} config - Domain configuration
+ * @param {Object} domains - Available domains
+ * @returns {string} ESLint config file content
+ */
+export async function generateEslintConfig(config, domains) {
+  // ...
+}
+```
+
+## Anti-Patterns
+
+**Avoid:**
+- ❌ **Monolithic files** (>250 lines) - Split into smaller modules
+- ❌ **Long functions** (>50 lines) - Extract helper functions
+- ❌ **Deep nesting** (>4 levels) - Early returns or separate functions
+- ❌ **Silent errors** - Always log/handle errors explicitly
+- ❌ **Global state** - Use parameters and return values
+- ❌ **Magic numbers** - Use named constants
+- ❌ **Generic names** - Avoid: `value`, `data`, `result`, `tmp`, `arr`, `obj`, `bool`, `item`
+
+
+## Ambiguity Tactics
+- Prefer explicit @domain/@domains on ambiguous constants
+- Use name cues (e.g., 'circleAngleDegrees')
+- Project-wide mapping via .ai-coding-guide.json → constantResolution
+
+---
+*See .ai-coding-guide.md for details*

--- a/lib/commands/setup/index.js
+++ b/lib/commands/setup/index.js
@@ -25,9 +25,12 @@ async function setupCommand(cwd, args) {
 
   // 2) Init phase: generate everything by default (AGENTS.md + ESLint); cursor remains opt-in
   const initArgs = { ...args, yes: true };
-  // Respect explicit opt-outs if user provided them
-  // (init defaults already generate both; --no-agents/--no-eslint disable)
+
+  // Ensure changes from init persist to .ai-coding-guide.json after learn
+  const prevForce = process.env.FORCE_AI_CONFIG;
+  process.env.FORCE_AI_CONFIG = '1';
   const code2 = initCommand(cwd, initArgs);
+  if (prevForce === undefined) delete process.env.FORCE_AI_CONFIG; else process.env.FORCE_AI_CONFIG = prevForce;
   return code2;
 }
 

--- a/lib/generators/agents-md.js
+++ b/lib/generators/agents-md.js
@@ -76,7 +76,7 @@ function writeAgentsMd(cwd, cfg) {
       md += `| Utilities | ${arch.maxFileLength.util || 200} | Single purpose |\n`;
       md += `| Generators| ${arch.maxFileLength.generator || 250} | Template logic |\n`;
       md += `| Components| ${arch.maxFileLength.component || 300} | UI complexity |\n`;
-      md += `| Tests     | ∞ | No limit |\n`;
+      md += '| Tests     | ∞ | No limit |\n';
       md += `| Default   | ${arch.maxFileLength.default || 250} | General files |\n\n`;
     }
     
@@ -122,13 +122,13 @@ function writeAgentsMd(cwd, cfg) {
   // Add forbidden names if they exist
   const forbiddenNames = cfg.antiPatterns && cfg.antiPatterns.forbiddenNames || [];
   if (forbiddenNames.length > 0) {
-    md += `\n- ❌ **Generic names** - Avoid: ` + '`' + forbiddenNames.join('`, `') + '`';
+    md += '\n- ❌ **Generic names** - Avoid: ' + '`' + forbiddenNames.join('`, `') + '`';
   }
   
   md += '\n\n';
   
   // Ambiguity tactics
-  md += `\n## Ambiguity Tactics\n- Prefer explicit @domain/@domains on ambiguous constants\n- Use name cues (e.g., 'circleAngleDegrees')\n- Project-wide mapping via .ai-coding-guide.json → constantResolution\n\n---\n*See .ai-coding-guide.md for details*\n`;
+  md += '\n## Ambiguity Tactics\n- Prefer explicit @domain/@domains on ambiguous constants\n- Use name cues (e.g., \'circleAngleDegrees\')\n- Project-wide mapping via .ai-coding-guide.json → constantResolution\n\n---\n*For machine-readable format, see .ai-coding-guide.json*\n';
   fs.writeFileSync(file, md);
   console.log(`Wrote ${file}`);
 }

--- a/tests/integration/cli-agents-footer.test.js
+++ b/tests/integration/cli-agents-footer.test.js
@@ -1,0 +1,29 @@
+/* eslint-env mocha */
+/* global describe, it */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+function runCliInit(tmpDir, args = []) {
+  const cliPath = path.resolve(__dirname, '..', '..', 'bin', 'cli.js');
+  const env = { ...process.env, FORCE_AI_CONFIG: '1', FORCE_ESLINT_CONFIG: '1', SKIP_AI_REQUIREMENTS: '1' };
+  execFileSync('node', [cliPath, 'init', '--primary=dev-tools', '--yes', ...args], {
+    cwd: tmpDir,
+    env,
+    stdio: 'pipe'
+  });
+}
+
+describe('AGENTS.md footer references .ai-coding-guide.json', function () {
+  it('footer references .json and not .md', function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-agents-footer-'));
+    runCliInit(tmp);
+    const agents = fs.readFileSync(path.join(tmp, 'AGENTS.md'), 'utf8');
+    assert.ok(agents.includes('.ai-coding-guide.json'));
+    assert.ok(!agents.includes('.ai-coding-guide.md'));
+  });
+});

--- a/tests/integration/cli-setup-architecture-json.test.js
+++ b/tests/integration/cli-setup-architecture-json.test.js
@@ -1,0 +1,30 @@
+/* eslint-env mocha */
+/* global describe, it */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+function runCliSetup(tmpDir, args = []) {
+  const cliPath = path.resolve(__dirname, '..', '..', 'bin', 'cli.js');
+  const env = { ...process.env, FORCE_AI_CONFIG: '1', FORCE_ESLINT_CONFIG: '1', SKIP_AI_REQUIREMENTS: '1', NODE_ENV: 'test' };
+  execFileSync('node', [cliPath, 'setup', '--yes', '--primary=dev-tools', ...args], {
+    cwd: tmpDir,
+    env,
+    stdio: 'pipe'
+  });
+}
+
+describe('setup persists architecture and domainPriority into JSON', function () {
+  it('writes architecture and domainPriority to .ai-coding-guide.json', function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-setup-arch-json-'));
+    runCliSetup(tmp);
+    const cfg = JSON.parse(fs.readFileSync(path.join(tmp, '.ai-coding-guide.json'), 'utf8'));
+    assert.ok(cfg.architecture, 'architecture section should exist');
+    assert.ok(cfg.architecture.maxFileLength, 'architecture.maxFileLength should exist');
+    assert.ok(Array.isArray(cfg.domainPriority) && cfg.domainPriority.length > 0, 'domainPriority should be populated');
+  });
+});


### PR DESCRIPTION
Phase 1 of #133 – Persist architecture in JSON + fix AGENTS footer

What this changes
- setup: ensure architecture + domainPriority from init persist into .ai-coding-guide.json after learn
  - Force JSON overwrite (FORCE_AI_CONFIG=1) around init within setup so the post-learn config is updated
- AGENTS.md: update footer to reference .ai-coding-guide.json (remove stale .md reference)

Tests added
- tests/integration/cli-setup-architecture-json.test.js
  - Verifies setup --yes --primary=dev-tools writes architecture and domainPriority to .ai-coding-guide.json
- tests/integration/cli-agents-footer.test.js
  - Verifies AGENTS.md footer references .ai-coding-guide.json and not .md

Why
- Previously, learn wrote .ai-coding-guide.json, then init computed architecture/domainPriority but the JSON was not overwritten, causing missing architecture in JSON (docs vs enforcement mismatch)
- Footer still referenced a removed file (.ai-coding-guide.md)

Validation
- All tests passing locally

Follow-ups (Phase 2+ in #133)
- setup --yes domain inference/validation (require --primary or infer from detectProjectContext)
- learn interactive: suggest inferred domain and set domains + domainPriority
- Docs polish

Part of #133 – Phase 1
