### PR TITLE
feat(setup): domain inference/validation for --yes mode

### DIFF
--- a/lib/commands/setup/index.js
+++ b/lib/commands/setup/index.js
@@ -5,6 +5,7 @@ const path = require('path');
 async function setupCommand(cwd, args) {
   const { learnCommand } = require(path.join(__dirname, '..', 'learn'));
   const { initCommand } = require(path.join(__dirname, '..', 'init'));
+  const { detectProjectContext } = require(path.join(__dirname, '..', '..', 'utils', 'project-detection'));
 
   // 1) Learn phase (unless skipped)
   const skipLearn = !!(args['skip-learn'] || args.skipLearn);
@@ -25,6 +26,22 @@ async function setupCommand(cwd, args) {
 
   // 2) Init phase: generate everything by default (AGENTS.md + ESLint); cursor remains opt-in
   const initArgs = { ...args, yes: true };
+
+  // Phase 2: Domain handling for non-interactive setup
+  if (initArgs.yes && !initArgs.primary) {
+    const ctx = detectProjectContext(cwd);
+    const inferred = ctx && ctx.type === 'dev-tools' ? 'dev-tools'
+      : ctx && ctx.type === 'cli' ? 'cli'
+      : ctx && ctx.type === 'web-app' ? 'web-app'
+      : null;
+    if (inferred) {
+      initArgs.primary = inferred;
+    } else {
+      console.error('Error: --primary required when using --yes (unable to infer domain)');
+      console.error('Example: npx eslint-plugin-ai-code-snifftest setup --yes --primary=dev-tools');
+      return 1;
+    }
+  }
 
   // Ensure changes from init persist to .ai-coding-guide.json after learn
   const prevForce = process.env.FORCE_AI_CONFIG;

--- a/tests/integration/cli-setup-domain-validation.test.js
+++ b/tests/integration/cli-setup-domain-validation.test.js
@@ -1,0 +1,54 @@
+/* eslint-env mocha */
+/* global describe, it */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync, execFileSync } = require('child_process');
+
+function cliPath() {
+  return path.resolve(__dirname, '..', '..', 'bin', 'cli.js');
+}
+
+function withTmpDir(prefix, fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  try { fn(tmp); } finally { fs.rmSync(tmp, { recursive: true, force: true }); }
+}
+
+describe('setup --yes domain inference/validation', function () {
+  this.timeout(8000);
+
+  it('errors when --yes has no --primary and domain cannot be inferred', function () {
+    withTmpDir('cli-setup-no-domain-', (tmp) => {
+      // minimal package.json without clues
+      fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'my-app' }, null, 2));
+      const env = { ...process.env, SKIP_AI_REQUIREMENTS: '1' };
+      const res = spawnSync('node', [cliPath(), 'setup', '--yes'], { cwd: tmp, env, encoding: 'utf8' });
+      assert.notStrictEqual(res.status, 0, 'should exit non-zero');
+      assert.ok(/--primary required/i.test(res.stderr || res.stdout), 'should print guidance about --primary');
+    });
+  });
+
+  it('infers dev-tools for eslint plugin projects (no --primary)', function () {
+    withTmpDir('cli-setup-infer-devtools-', (tmp) => {
+      fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'eslint-plugin-foo' }, null, 2));
+      const env = { ...process.env, SKIP_AI_REQUIREMENTS: '1', FORCE_AI_CONFIG: '1', FORCE_ESLINT_CONFIG: '1' };
+      execFileSync('node', [cliPath(), 'setup', '--yes'], { cwd: tmp, env, stdio: 'pipe' });
+      const cfg = JSON.parse(fs.readFileSync(path.join(tmp, '.ai-coding-guide.json'), 'utf8'));
+      assert.strictEqual(cfg.domains.primary, 'dev-tools');
+      assert.ok(Array.isArray(cfg.domainPriority) && cfg.domainPriority[0] === 'dev-tools');
+    });
+  });
+
+  it('accepts explicit --primary and succeeds', function () {
+    withTmpDir('cli-setup-primary-', (tmp) => {
+      fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'my-app' }, null, 2));
+      const env = { ...process.env, SKIP_AI_REQUIREMENTS: '1', FORCE_AI_CONFIG: '1', FORCE_ESLINT_CONFIG: '1' };
+      execFileSync('node', [cliPath(), 'setup', '--yes', '--primary=dev-tools'], { cwd: tmp, env, stdio: 'pipe' });
+      const cfg = JSON.parse(fs.readFileSync(path.join(tmp, '.ai-coding-guide.json'), 'utf8'));
+      assert.strictEqual(cfg.domains.primary, 'dev-tools');
+    });
+  });
+});


### PR DESCRIPTION
Phase 2 of #133 – setup --yes domain inference/validation

What this changes
- setup: require `--primary` in `--yes` mode unless domain can be inferred from project type
  - Inference via `detectProjectContext(cwd)`: dev-tools (eslint-plugin-*), cli (has `bin`), web-app (react/vue)
  - If not inferable, print clear error with example usage and exit non-zero

Tests added
- tests/integration/cli-setup-domain-validation.test.js
  - errors when `--yes` has no `--primary` and cannot infer domain
  - infers `dev-tools` for eslint-plugin projects
  - accepts explicit `--primary` and succeeds

Why
- Prevents silent "general" defaults in non-interactive mode
- Produces project-appropriate domain and priority without surprises

Validation
- Full test suite passing locally

Part of #133 – Phase 2
