### PR TITLE
feat(learn): interactive domain suggestion and apply on accept

### DIFF
--- a/lib/commands/learn/index.js
+++ b/lib/commands/learn/index.js
@@ -7,6 +7,7 @@ const { deepMerge, loadProjectConfigFile, writeProjectConfigFile } = require(pat
 const { shouldEnableArchitecture, normalizeBoolean } = require(path.join(__dirname, '..', '..', 'utils', 'arch-switch'));
 const { writeAgentsMd } = require(path.join(__dirname, '..', '..', 'generators', 'agents-md'));
 const { writeEslintConfig } = require(path.join(__dirname, '..', '..', 'generators', 'eslint-config'));
+const { detectProjectContext } = require(path.join(__dirname, '..', '..', 'utils', 'project-detection'));
 
 async function learnInteractiveCommand(cwd, args, findings, rec, currentCfg) {
   const readline = require('readline');
@@ -16,6 +17,24 @@ async function learnInteractiveCommand(cwd, args, findings, rec, currentCfg) {
     const nextCfg = JSON.parse(JSON.stringify(currentCfg));
     console.log('\nLearn: Reconciliation Report');
     console.log(`Score: ${rec.score.overall}/100`);
+
+    // Phase 3: suggest inferred domain
+    try {
+      const ctx = detectProjectContext(cwd);
+      const inferred = ctx && ctx.type === 'dev-tools' ? 'dev-tools'
+        : ctx && ctx.type === 'cli' ? 'cli'
+        : ctx && ctx.type === 'web-app' ? 'web-app'
+        : null;
+      if (inferred) {
+        const pick = (await ask(`\nDetected domain: ${inferred}. Use this as primary? (Y/n): `)).trim().toLowerCase();
+        if (!pick || pick.startsWith('y')) {
+          nextCfg.domains = nextCfg.domains || { primary: 'general', additional: [] };
+          nextCfg.domains.primary = inferred;
+          const addl = Array.isArray(nextCfg.domains.additional) ? nextCfg.domains.additional : [];
+          nextCfg.domainPriority = [inferred, ...addl].filter(Boolean);
+        }
+      }
+    } catch { /* ignore detection errors */ }
     if (rec.score && rec.score.breakdown) {
       console.log('Breakdown:', rec.score.breakdown);
     }

--- a/tests/integration/cli-learn-domain-suggestion.test.js
+++ b/tests/integration/cli-learn-domain-suggestion.test.js
@@ -1,0 +1,58 @@
+/* eslint-env mocha */
+/* global describe, it */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+function runInteractiveLearnAcceptAll(tmpDir) {
+  return new Promise((resolve, reject) => {
+    const cliPath = path.resolve(__dirname, '..', '..', 'bin', 'cli.js');
+    const env = { ...process.env, SKIP_AI_REQUIREMENTS: '1', FORCE_AI_CONFIG: '1' };
+    const child = spawn('node', [cliPath, 'learn', '--interactive', '--sample=40', '--no-cache'], { cwd: tmpDir, env, stdio: ['pipe','pipe','pipe'] });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+
+    // Press Enter many times to accept defaults, including domain suggestion
+    let remaining = 14;
+    const iv = setInterval(() => {
+      if (remaining <= 0) {
+        clearInterval(iv);
+        child.stdin.end();
+        return;
+      }
+      child.stdin.write('\n');
+      remaining -= 1;
+    }, 80);
+
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+
+    setTimeout(() => { try { child.kill(); } catch (e) { /* ignore */ } reject(new Error('timeout')); }, 30000);
+  });
+}
+
+describe('learn interactive domain suggestion', function () {
+  this.timeout(35000);
+
+  it('suggests and applies inferred domain when accepted', async function () {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-learn-suggest-domain-'));
+    // Ensure project suggests dev-tools
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'eslint-plugin-xyz' }, null, 2));
+    // Add minimal code so scan runs
+    fs.writeFileSync(path.join(tmp, 'index.js'), 'const x=1; function f(){return x;}\n');
+
+    const res = await runInteractiveLearnAcceptAll(tmp);
+    assert.strictEqual(res.code, 0, res.stderr);
+
+    const cfg = JSON.parse(fs.readFileSync(path.join(tmp, '.ai-coding-guide.json'), 'utf8'));
+    assert.strictEqual(cfg.domains.primary, 'dev-tools');
+    assert.ok(Array.isArray(cfg.domainPriority) && cfg.domainPriority[0] === 'dev-tools');
+  });
+});


### PR DESCRIPTION
Phase 3 of #133 – learn interactive domain suggestion

What this changes
- learn (interactive): suggests inferred domain via detectProjectContext (dev-tools/cli/web-app)
  - Prompt: "Detected domain: <x>. Use this as primary? (Y/n)"
  - On accept: sets domains.primary and domainPriority accordingly before applying changes

Tests added
- tests/integration/cli-learn-domain-suggestion.test.js
  - Project named eslint-plugin-* → inferred dev-tools; pressing Enter throughout applies suggestion

Why
- Helps users set the correct primary domain during learn without manual flags

Validation
- Full test suite passing locally

Part of #133 – Phase 3
