### PR TITLE
docs: clarify setup --yes behavior; document learn domain suggestion

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -36,6 +36,7 @@ npx eslint-plugin-ai-code-snifftest setup [options]
 ### Behavior
 - Interactive by default: runs learn reconciliation wizard, then writes init outputs with defaults.
 - Non-interactive: `--yes` runs learn in strict apply mode and init with defaults (AGENTS.md + ESLint).
+  - Domain required: pass `--primary` or ensure project type can be inferred (eslint-plugin → dev-tools, CLI with `bin` → cli, React/Vue → web-app). If not inferable, setup exits with guidance.
 - Skip learn with `--skip-learn` to only run init.
 
 ### Common options
@@ -103,7 +104,9 @@ If `--primary` is omitted and stdin is TTY (or `FORCE_CLI_INTERACTIVE=1`), the w
 
 Note: `.ai-coding-guide.md` is not generated.
 
-In interactive learn, after reconciliation you’ll be offered to generate `AGENTS.md` and `eslint.config.mjs` immediately (defaults on; honor `--no-agents`, `--no-eslint`, and `--arch`/`--no-arch`).
+In interactive learn, after reconciliation you’ll be offered to:
+- Accept an inferred domain for `domains.primary` (e.g., dev-tools/cli/web-app)
+- Generate `AGENTS.md` and `eslint.config.mjs` immediately (defaults on; honor `--no-agents`, `--no-eslint`, and `--arch`/`--no-arch`).
 
 ### Architecture guardrails
 Enabled by default. Disable with `--no-arch` or `--arch=false`.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -19,9 +19,14 @@ This document summarizes breaking/behavioral changes introduced across UX issue 
   - `--skip-learn` to only run `init`
 
 ### Learn Enhancements
+- Interactive `learn` suggests an inferred domain (dev-tools/cli/web-app) and applies on accept
 - Interactive `learn` offers to generate AGENTS.md and eslint.config.mjs at the end
   - Default-on; honors `--no-agents` and `--no-eslint`
   - Honors `--arch` / `--no-arch` by updating `.ai-coding-guide.json` first
+
+### Fixes
+- Architecture + domainPriority persistence in `.ai-coding-guide.json` when running `setup` after `learn`
+- `AGENTS.md` footer updated to reference `.ai-coding-guide.json`
 
 ### Deprecations (soft)
 - `--agents` and `--eslint` are no longer required (defaults are on)


### PR DESCRIPTION
Phase 4 of #133 – Docs polish

Changes
- docs/CLI.md:
  - Clarify setup non-interactive behavior: `--yes` requires `--primary` or an inferable project type; else exits with guidance
  - Document learn (interactive) domain suggestion prompt
- docs/MIGRATION.md:
  - Add notes on persistence of architecture/domainPriority in JSON and AGENTS footer updates

Validation
- Full test suite passing locally

Part of #133 – Phase 4
