### PR TITLE
fix(cli): prevent double execution causing duplicated interactive input

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -47,4 +47,3 @@ function main() {
 }
 
 main();
-main();


### PR DESCRIPTION
Root cause
- bin/cli.js invoked main() twice, so the process read stdin twice and echoed inputs (e.g., Y -> yy) and duplicated side effects.

Fix
- Remove the duplicate main() invocation so main() only executes once.

Repro
- Before: `node bin/cli.js learn --interactive` and answer Y → echoes `yy` and repeats prompts.
- After: Single keypress accepted; no duplicated prompts or output.

Notes
- Affects interactive flows (learn, setup, init-interactive). Non-interactive flows unaffected.
