### PR TITLE
fix(schema): include external constants keys in ai-coding-guide schema

### DIFF
--- a/lib/config/ai-coding-guide.schema.json
+++ b/lib/config/ai-coding-guide.schema.json
@@ -54,6 +54,17 @@
         "forbiddenTerms": { "type": "array", "items": { "type": "string" } }
       }
     },
+    "experimentalExternalConstants": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable experimental discovery/use of external constants"
+    },
+    "externalConstantsAllowlist": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [],
+      "description": "Package names or patterns allowed for external constants discovery"
+    },
     "minimumMatch": {
       "type": "number",
       "minimum": 0,


### PR DESCRIPTION
Fixes #118

Problem
- .ai-coding-guide.schema.json had `additionalProperties: false` but did not declare:
  - `experimentalExternalConstants` (boolean)
  - `externalConstantsAllowlist` (string[])
- This caused validation warnings when reading project config.

Solution
- Add both properties with types/defaults and descriptions.

Validation
- `readProjectConfig` no longer emits schema warnings
- `npm test` passes (570 passing, 3 pending)

Notes
- Prerequisite for #74 (flip default to true). After this merges, we can flip the default and update docs/tests.
