### PR TITLE
feat(#146): domain hints, snippets in analysis examples, and tunable thresholds across analyze/plan/create-issues

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -183,7 +183,7 @@ Summarize ESLint JSON results with categories, domain context, and a rough effor
 
 ### Synopsis
 ```bash
-npx eslint-plugin-ai-code-snifftest analyze [--input=lint-results.json] [--output=analysis-report.md] [--format=markdown|json|html]
+npx eslint-plugin-ai-code-snifftest analyze [--input=lint-results.json] [--output=analysis-report.md] [--format=markdown|json|html] [--top-files=10] [--min-count=1] [--max-examples=5]
 ```
 
 ### Behavior
@@ -196,6 +196,9 @@ npx eslint-plugin-ai-code-snifftest analyze [--input=lint-results.json] [--outpu
 - --input, -i: Path to ESLint JSON (default: lint-results.json)
 - --output, -o: Output file (default: analysis-report.md)
 - --format: markdown (default) | json | html
+- --top-files: limit for hotspot lists (default: 10)
+- --min-count: minimum occurrences to include in lists (default: 1)
+- --max-examples: max examples per section (default: 5)
 
 ---
 
@@ -205,7 +208,7 @@ Create a phased roadmap (Quick Wins, Domain Cleanup, Refactoring, Polish) from a
 
 ### Synopsis
 ```bash
-npx eslint-plugin-ai-code-snifftest plan [--input=lint-results.json] [--output=FIXES-ROADMAP.md] [--phases=4] [--team-size=1]
+npx eslint-plugin-ai-code-snifftest plan [--input=lint-results.json] [--output=FIXES-ROADMAP.md] [--phases=4] [--team-size=1] [--top-files=10] [--min-count=1]
 ```
 
 ### Options
@@ -213,6 +216,8 @@ npx eslint-plugin-ai-code-snifftest plan [--input=lint-results.json] [--output=F
 - --output, -o: Output file (default: FIXES-ROADMAP.md)
 - --phases: Number of phases to include (default: 4)
 - --team-size: Reserved for future capacity planning (default: 1)
+- --top-files: limit for hotspot lists (default: 10)
+- --min-count: minimum occurrences to include in lists (default: 1)
 
 ---
 
@@ -222,7 +227,7 @@ Generate issue markdown files from ESLint JSON analysis. Files-only: does NOT cr
 
 ### Synopsis
 ```bash
-npx eslint-plugin-ai-code-snifftest create-issues [--input=lint-results.json] [--output=issues] [--format=markdown|json] [--include-commands=github-cli|gitlab-cli] [--labels="lint,tech-debt"]
+npx eslint-plugin-ai-code-snifftest create-issues [--input=lint-results.json] [--output=issues] [--format=markdown|json] [--include-commands=github-cli|gitlab-cli] [--labels="lint,tech-debt"] [--top-files=10] [--min-count=1]
 ```
 
 ### Behavior
@@ -237,6 +242,8 @@ npx eslint-plugin-ai-code-snifftest create-issues [--input=lint-results.json] [-
 - --format: markdown (default) | json
 - --include-commands: github-cli (default) | gitlab-cli
 - --labels: Labels to apply in CLI examples (default: "lint,tech-debt")
+- --top-files: limit for hotspot lists (default: 10)
+- --min-count: minimum occurrences to include in lists (default: 1)
 
 ---
 

--- a/lib/commands/analyze/domain.js
+++ b/lib/commands/analyze/domain.js
@@ -78,4 +78,36 @@ function attachDomainContext(categories, cfg) {
   return categories;
 }
 
-module.exports = { buildDomainData, inferDomainForMessage, attachDomainContext };
+function getDomainHints(categories, cfg) {
+  // Build domain data across all known domains to infer hints
+  const all = { byDomain: {}, priority: [], allowed: Object.keys(constantsLib.DOMAINS) };
+  for (const d of Object.keys(constantsLib.DOMAINS)) {
+    const mod = constantsLib.getDomain(d);
+    if (!mod) continue;
+    all.byDomain[d] = {
+      constants: Array.isArray(mod.constants) ? mod.constants.slice() : [],
+      terms: Array.isArray(mod.terms) ? mod.terms.map(String) : []
+    };
+  }
+  const counts = Object.create(null);
+  function annotate(list) {
+    for (const rec of list || []) {
+      const d = inferDomainForMessage(rec.message, all);
+      if (d) counts[d] = (counts[d] || 0) + 1;
+    }
+  }
+  annotate(categories.magicNumbers || []);
+  annotate(categories.domainTerms || []);
+  annotate(categories.complexity || []);
+  annotate(categories.architecture || []);
+  // Exclude configured allowed domains
+  const allowed = resolveAllowedDomains(cfg || {});
+  const hints = Object.entries(counts)
+    .filter(([d]) => !allowed.includes(d))
+    .map(([domain, count]) => ({ domain, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+  return hints;
+}
+
+module.exports = { buildDomainData, inferDomainForMessage, attachDomainContext, getDomainHints };

--- a/lib/commands/analyze/index.js
+++ b/lib/commands/analyze/index.js
@@ -8,6 +8,8 @@ const { estimateEffort } = require('./estimator');
 const { writeAnalysisReport } = require('./reporter');
 const { attachDomainContext } = require('./domain');
 
+function numArg(v, d) { const n = Number(v); return Number.isFinite(n) && n > 0 ? n : d; }
+
 function analyzeCommand(cwd, args) {
   try {
     const input = args._ && args._[1] ? args._[1] : (args.input || 'lint-results.json');
@@ -18,14 +20,17 @@ function analyzeCommand(cwd, args) {
     const raw = fs.readFileSync(file, 'utf8');
     const json = JSON.parse(raw);
     const cfg = readProjectConfig({ getFilename: () => path.join(cwd, 'placeholder.js'), getCwd: () => cwd });
-    
     let categories = categorizeViolations(json, cfg);
     categories = attachDomainContext(categories, cfg);
     const effort = estimateEffort(categories);
-    const outPath = path.join(cwd, outFile);
 
+    const topFiles = numArg(args['top-files'] || args.topFiles, 10);
+    const minCount = numArg(args['min-count'] || args.minCount, 1);
+    const maxExamples = numArg(args['max-examples'] || args.maxExamples, 5);
+
+    const outPath = path.join(cwd, outFile);
     if (format === 'markdown') {
-      writeAnalysisReport(outPath, { categories, effort, cfg });
+      writeAnalysisReport(outPath, { categories, effort, cfg, topFiles, minCount, maxExamples });
     } else if (format === 'json') {
       fs.writeFileSync(outPath, JSON.stringify({ categories, effort }, null, 2) + '\n');
     } else if (format === 'html') {

--- a/lib/commands/analyze/reporter.js
+++ b/lib/commands/analyze/reporter.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
+const { getDomainHints } = require('./domain');
 
-function writeAnalysisReport(outPath, { categories, effort, returnString } = {}) {
+function writeAnalysisReport(outPath, { categories, effort, returnString, topFiles = 10, minCount = 1, maxExamples = 5, cfg } = {}) {
   const lines = [];
   lines.push('# Analysis Report');
   lines.push('');
@@ -20,6 +22,15 @@ function writeAnalysisReport(outPath, { categories, effort, returnString } = {})
     const tops = categories.domainSummary.slice(0, 5);
     tops.forEach(d => lines.push(`- ${d.domain}: ${d.count}`));
     lines.push('');
+    const allZero = tops.every(d => (d.count || 0) === 0);
+    if (allZero) {
+      const hints = getDomainHints(categories, cfg) || [];
+      if (hints.length) {
+        lines.push('### Domain Hints');
+        hints.forEach(h => lines.push(`- ${h.domain}: ${h.count}`));
+        lines.push('');
+      }
+    }
   }
   // Per-category breakdowns
   function byRule(list) {
@@ -30,15 +41,28 @@ function writeAnalysisReport(outPath, { categories, effort, returnString } = {})
     }
     return Array.from(m.entries()).sort((a, b) => b[1] - a[1]);
   }
-  function topFiles(list, limit = 10) {
+  function topFilesFn(list, limit = 10, min = 1) {
     const m = new Map();
     for (const r of list || []) {
       const k = String(r.filePath || 'unknown');
       m.set(k, (m.get(k) || 0) + 1);
     }
-    return Array.from(m.entries()).sort((a,b)=>b[1]-a[1]).slice(0, limit);
+    return Array.from(m.entries()).filter(([,c]) => c >= min).sort((a,b)=>b[1]-a[1]).slice(0, limit);
   }
   function sample(list, n = 5) { return (list || []).slice(0, n); }
+  function readSnippet(filePath, line, context = 2) {
+    try {
+      const p = path.isAbsolute(filePath) ? filePath : path.join(process.cwd(), filePath);
+      const content = fs.readFileSync(p, 'utf8');
+      const rows = content.split(/\r?\n/);
+      const idx = Math.max(0, (Number(line) || 1) - 1);
+      const start = Math.max(0, idx - context);
+      const end = Math.min(rows.length, idx + context + 1);
+      return rows.slice(start, end).join('\n');
+    } catch (_) {
+      return null;
+    }
+  }
 
   const sections = [
     ['Complexity', categories.complexity],
@@ -54,16 +78,26 @@ function writeAnalysisReport(outPath, { categories, effort, returnString } = {})
       rules.slice(0, 10).forEach(([rule, count]) => lines.push(`- ${rule}: ${count}`));
       lines.push('');
     }
-    const files = topFiles(list, 10);
+    const files = topFilesFn(list, topFiles, minCount);
     if (files.length) {
       lines.push('### Top files');
       files.forEach(([f, count]) => lines.push(`- ${f}: ${count}`));
       lines.push('');
     }
-    const examples = sample(list, 5);
+    const examples = sample(list, maxExamples);
     if (examples.length) {
       lines.push('### Examples');
-      examples.forEach(r => lines.push(`- ${r.filePath}:${r.line || 0} ${r.ruleId} → ${r.message}`));
+      examples.forEach(r => {
+        lines.push(`- ${r.filePath}:${r.line || 0} ${r.ruleId} → ${r.message}`);
+        const snippet = readSnippet(r.filePath, r.line, 2);
+        if (snippet) {
+          lines.push('');
+          lines.push('```js');
+          lines.push(snippet);
+          lines.push('```');
+          lines.push('');
+        }
+      });
       lines.push('');
     }
   }

--- a/lib/commands/create-issues/index.js
+++ b/lib/commands/create-issues/index.js
@@ -5,6 +5,8 @@ const fs = require('fs');
 const { generateIssues, generateInstructions } = require('./markdown');
 const { readProjectConfig } = require(path.join(__dirname, '..', '..', 'utils', 'project-config'));
 
+function numArg(v, d) { const n = Number(v); return Number.isFinite(n) && n > 0 ? n : d; }
+
 function createIssuesCommand(cwd, args) {
   try {
     const input = args._ && args._[1] ? args._[1] : (args.input || 'lint-results.json');
@@ -21,8 +23,12 @@ function createIssuesCommand(cwd, args) {
     const json = JSON.parse(fs.readFileSync(file, 'utf8'));
     const cfg = readProjectConfig({ getFilename: () => path.join(cwd, 'placeholder.js'), getCwd: () => cwd });
 
+    const topFiles = numArg(args['top-files'] || args.topFiles, 10);
+    const minCount = numArg(args['min-count'] || args.minCount, 1);
+    const maxExamples = numArg(args['max-examples'] || args.maxExamples, 5);
+
     fs.mkdirSync(path.join(cwd, outDir), { recursive: true });
-    generateIssues(cwd, outDir, json, { format, cfg });
+    generateIssues(cwd, outDir, json, { format, cfg, topFiles, minCount, maxExamples });
     generateInstructions(cwd, outDir, { includeCmd, labels });
     return 0;
   } catch (e) {

--- a/lib/commands/create-issues/markdown.js
+++ b/lib/commands/create-issues/markdown.js
@@ -7,6 +7,8 @@ const { attachDomainContext } = require('../analyze/domain');
 
 function w(p, s) { fs.writeFileSync(p, s); }
 
+function clip(n, lo, hi) { return Math.max(lo, Math.min(hi, n)); }
+
 function extractNumbersFromMessages(list) {
   const nums = new Map();
   for (const r of list || []) {
@@ -29,7 +31,7 @@ function groupByDomain(list) {
   return out;
 }
 
-function buildMarkdownSections(cats, which /* 'magic'|'terms'|'complexity'|'architecture'|null */) {
+function buildMarkdownSections(cats, which /* 'magic'|'terms'|'complexity'|'architecture'|null */, { topFiles = 10, minCount = 1 } = {}) {
   const lines = [];
   const topDomains = (cats.domainSummary || []).slice(0, 5).map(d => `- ${d.domain}: ${d.count}`).join('\n');
   if (topDomains) {
@@ -76,7 +78,7 @@ function buildMarkdownSections(cats, which /* 'magic'|'terms'|'complexity'|'arch
   if (includeComplexity) {
     const files = new Map();
     (cats.complexity || []).forEach(r => files.set(r.filePath, (files.get(r.filePath) || 0) + 1));
-    const top = Array.from(files.entries()).sort((a,b)=>b[1]-a[1]).slice(0, 10);
+    const top = Array.from(files.entries()).filter(([,c]) => c >= minCount).sort((a,b)=>b[1]-a[1]).slice(0, clip(topFiles,1,50));
     if (top.length) {
       lines.push('### Complexity Hotspots (top files)');
       top.forEach(([f, c]) => lines.push(`- ${f}: ${c}`));
@@ -87,7 +89,7 @@ function buildMarkdownSections(cats, which /* 'magic'|'terms'|'complexity'|'arch
   if (includeArch) {
     const files = new Map();
     (cats.architecture || []).forEach(r => files.set(r.filePath, (files.get(r.filePath) || 0) + 1));
-    const top = Array.from(files.entries()).sort((a,b)=>b[1]-a[1]).slice(0, 10);
+    const top = Array.from(files.entries()).filter(([,c]) => c >= minCount).sort((a,b)=>b[1]-a[1]).slice(0, clip(topFiles,1,50));
     if (top.length) {
       lines.push('### Architecture Hotspots (top files)');
       top.forEach(([f, c]) => lines.push(`- ${f}: ${c}`));
@@ -104,13 +106,13 @@ function buildMarkdownSections(cats, which /* 'magic'|'terms'|'complexity'|'arch
   return lines.join('\n');
 }
 
-function writeMarkdownIssues(outPath, cats) {
+function writeMarkdownIssues(outPath, cats, opts = {}) {
   function section(title, preface, which) {
     const parts = [];
     parts.push(`# ${title}`);
     parts.push('');
     if (preface) { parts.push(preface); parts.push(''); }
-    parts.push(buildMarkdownSections(cats, which));
+    parts.push(buildMarkdownSections(cats, which, opts));
     return parts.join('\n');
   }
   const files = [
@@ -146,7 +148,7 @@ function generateIssues(cwd, outDir, eslintJson /* array */, opts = {}) {
     writeJsonIndex(outPath, cats);
     return;
   }
-  writeMarkdownIssues(outPath, cats);
+  writeMarkdownIssues(outPath, cats, { topFiles: opts.topFiles, minCount: opts.minCount });
 }
 
 function generateInstructions(cwd, outDir, { includeCmd = 'github-cli', labels = 'lint,tech-debt' } = {}) {

--- a/lib/commands/plan/index.js
+++ b/lib/commands/plan/index.js
@@ -7,6 +7,8 @@ const { categorizeViolations } = require('../analyze/categorizer');
 const { createPhases } = require('./phaser');
 const { writeRoadmap } = require('./roadmap');
 
+function numArg(v, d) { const n = Number(v); return Number.isFinite(n) && n > 0 ? n : d; }
+
 function planCommand(cwd, args) {
   try {
     const input = args._ && args._[1] ? args._[1] : (args.input || 'lint-results.json');
@@ -21,7 +23,9 @@ function planCommand(cwd, args) {
     const cfg = readProjectConfig({ getFilename: () => path.join(cwd, 'placeholder.js'), getCwd: () => cwd });
     const categories = categorizeViolations(json, cfg);
     const phases = createPhases(categories, { phases: phasesN, teamSize: team, cfg });
-    writeRoadmap(path.join(cwd, outFile), { phases, categories, cfg });
+    const topFiles = numArg(args['top-files'] || args.topFiles, 10);
+    const minCount = numArg(args['min-count'] || args.minCount, 1);
+    writeRoadmap(path.join(cwd, outFile), { phases, categories, cfg, topFiles, minCount });
     return 0;
   } catch (e) {
     console.error(`plan failed: ${e && e.message}`);

--- a/lib/commands/plan/roadmap.js
+++ b/lib/commands/plan/roadmap.js
@@ -2,25 +2,25 @@
 
 const fs = require('fs');
 
-function countByRule(list) {
+function countByRule(list, min = 1) {
   const m = new Map();
   for (const r of list || []) {
     const k = String(r.ruleId || 'unknown');
     m.set(k, (m.get(k) || 0) + 1);
   }
-  return Array.from(m.entries()).sort((a,b)=>b[1]-a[1]);
+  return Array.from(m.entries()).filter(([,c]) => c >= min).sort((a,b)=>b[1]-a[1]);
 }
 
-function topFiles(list, limit = 10) {
+function topFiles(list, limit = 10, min = 1) {
   const m = new Map();
   for (const r of list || []) {
     const k = String(r.filePath || 'unknown');
     m.set(k, (m.get(k) || 0) + 1);
   }
-  return Array.from(m.entries()).sort((a,b)=>b[1]-a[1]).slice(0, limit);
+  return Array.from(m.entries()).filter(([,c]) => c >= min).sort((a,b)=>b[1]-a[1]).slice(0, limit);
 }
 
-function writeRoadmap(outPath, { phases, categories } = {}) {
+function writeRoadmap(outPath, { phases, categories, topFiles: topFilesN = 10, minCount = 1 } = {}) {
   const lines = [];
   lines.push('# FIXES Roadmap');
   lines.push('');
@@ -48,9 +48,9 @@ function writeRoadmap(outPath, { phases, categories } = {}) {
     }
     if (ph.name === 'Domain Cleanup') {
       lines.push('### Tasks');
-      const termRules = countByRule(categories.domainTerms).slice(0, 5);
+      const termRules = countByRule(categories.domainTerms, minCount).slice(0, 5);
       termRules.forEach(([rule, count]) => lines.push(`- [ ] Tidy ${rule} (top ${count})`));
-      const files = topFiles(categories.domainTerms, 5);
+      const files = topFiles(categories.domainTerms, Math.min(5, topFilesN), minCount);
       if (files.length) {
         lines.push('### Top Files');
         files.forEach(([f, count]) => lines.push(`- ${f}: ${count}`));
@@ -62,9 +62,9 @@ function writeRoadmap(outPath, { phases, categories } = {}) {
     }
     if (ph.name === 'Refactoring') {
       lines.push('### Tasks');
-      const rules = countByRule(categories.complexity).slice(0, 5);
+      const rules = countByRule(categories.complexity, minCount).slice(0, 5);
       rules.forEach(([rule, count]) => lines.push(`- [ ] Reduce ${rule} (top ${count})`));
-      const files = topFiles(categories.complexity, 5);
+      const files = topFiles(categories.complexity, Math.min(5, topFilesN), minCount);
       if (files.length) {
         lines.push('### Top Files');
         files.forEach(([f, count]) => lines.push(`- ${f}: ${count}`));
@@ -76,9 +76,9 @@ function writeRoadmap(outPath, { phases, categories } = {}) {
     }
     if (ph.name === 'Polish') {
       lines.push('### Tasks');
-      const rules = countByRule(categories.architecture).slice(0, 5);
+      const rules = countByRule(categories.architecture, minCount).slice(0, 5);
       rules.forEach(([rule, count]) => lines.push(`- [ ] Tidy ${rule} (top ${count})`));
-      const files = topFiles(categories.architecture, 5);
+      const files = topFiles(categories.architecture, Math.min(5, topFilesN), minCount);
       if (files.length) {
         lines.push('### Top Files');
         files.forEach(([f, count]) => lines.push(`- ${f}: ${count}`));


### PR DESCRIPTION
Implements high-priority follow-ups from #146:

- Domain Hints: When configured domains show zero counts, add a Domain Hints section based on violation matching (without overriding configured domains)
- Analysis Examples: Include small code snippets around example lines (best-effort; falls back to path:line)
- Tunable thresholds: --top-files, --min-count, --max-examples supported in analyze; --top-files, --min-count in plan and create-issues; documented in docs/CLI.md

Notes
- No API calls, create-issues remains files-only
- Defaults: top-files=10, min-count=1, max-examples=5

Tests: full suite green (575 passing, 3 pending)
