### PR TITLE
feat(#146 issues): Domain Hints and code snippets in issues/*.md

### DIFF
--- a/lib/commands/create-issues/markdown.js
+++ b/lib/commands/create-issues/markdown.js
@@ -3,11 +3,25 @@
 const fs = require('fs');
 const path = require('path');
 const { categorizeViolations } = require('../analyze/categorizer');
-const { attachDomainContext } = require('../analyze/domain');
+const { attachDomainContext, getDomainHints } = require('../analyze/domain');
 
 function w(p, s) { fs.writeFileSync(p, s); }
 
 function clip(n, lo, hi) { return Math.max(lo, Math.min(hi, n)); }
+
+function readSnippet(filePath, line, context = 2) {
+  try {
+    const p = path.isAbsolute(filePath) ? filePath : path.join(process.cwd(), filePath);
+    const content = fs.readFileSync(p, 'utf8');
+    const rows = content.split(/\r?\n/);
+    const idx = Math.max(0, (Number(line) || 1) - 1);
+    const start = Math.max(0, idx - context);
+    const end = Math.min(rows.length, idx + context + 1);
+    return rows.slice(start, end).join('\n');
+  } catch (_) {
+    return null;
+  }
+}
 
 function extractNumbersFromMessages(list) {
   const nums = new Map();
@@ -31,13 +45,23 @@ function groupByDomain(list) {
   return out;
 }
 
-function buildMarkdownSections(cats, which /* 'magic'|'terms'|'complexity'|'architecture'|null */, { topFiles = 10, minCount = 1 } = {}) {
+function buildMarkdownSections(cats, which /* 'magic'|'terms'|'complexity'|'architecture'|null */, { topFiles = 10, minCount = 1, maxExamples = 5, cfg } = {}) {
   const lines = [];
-  const topDomains = (cats.domainSummary || []).slice(0, 5).map(d => `- ${d.domain}: ${d.count}`).join('\n');
+  const ds = Array.isArray(cats.domainSummary) ? cats.domainSummary.slice(0, 5) : [];
+  const topDomains = ds.map(d => `- ${d.domain}: ${d.count}`).join('\n');
   if (topDomains) {
     lines.push('### Detected Domains');
     lines.push(topDomains);
     lines.push('');
+    const allZero = ds.length > 0 && ds.every(d => (d.count || 0) === 0);
+    if (allZero) {
+      const hints = getDomainHints(cats, cfg) || [];
+      if (hints.length) {
+        lines.push('### Domain Hints');
+        hints.forEach(h => lines.push(`- ${h.domain}: ${h.count}`));
+        lines.push('');
+      }
+    }
   }
   const includeMagic = !which || which === 'magic';
   const includeTerms = !which || which === 'terms';
@@ -65,13 +89,30 @@ function buildMarkdownSections(cats, which /* 'magic'|'terms'|'complexity'|'arch
     if (termDomains.length) {
       lines.push('### Terminology to Review');
       for (const d of termDomains) {
-        const sample = (byDomTerms[d] || []).slice(0, 5).map(r => `- ${r.message}`).join('\n');
+        const termsList = (byDomTerms[d] || []);
+        const sample = termsList.slice(0, Math.min(5, maxExamples)).map(r => `- ${r.message}`).join('\n');
         if (sample) {
           lines.push(`- ${d}`);
           lines.push(sample);
         }
       }
       lines.push('');
+    }
+    // Examples with snippets
+    const examples = (cats.domainTerms || []).slice(0, Math.min(5, maxExamples));
+    if (examples.length) {
+      lines.push('### Examples');
+      for (const r of examples) {
+        lines.push(`- ${r.filePath}:${r.line || 0} ${r.ruleId} → ${r.message}`);
+        const snip = readSnippet(r.filePath, r.line, 2);
+        if (snip) {
+          lines.push('');
+          lines.push('```js');
+          lines.push(snip);
+          lines.push('```');
+          lines.push('');
+        }
+      }
     }
   }
 
@@ -84,6 +125,21 @@ function buildMarkdownSections(cats, which /* 'magic'|'terms'|'complexity'|'arch
       top.forEach(([f, c]) => lines.push(`- ${f}: ${c}`));
       lines.push('');
     }
+    const examples = (cats.complexity || []).slice(0, Math.min(5, maxExamples));
+    if (examples.length) {
+      lines.push('### Examples');
+      for (const r of examples) {
+        lines.push(`- ${r.filePath}:${r.line || 0} ${r.ruleId} → ${r.message}`);
+        const snip = readSnippet(r.filePath, r.line, 2);
+        if (snip) {
+          lines.push('');
+          lines.push('```js');
+          lines.push(snip);
+          lines.push('```');
+          lines.push('');
+        }
+      }
+    }
   }
 
   if (includeArch) {
@@ -94,6 +150,21 @@ function buildMarkdownSections(cats, which /* 'magic'|'terms'|'complexity'|'arch
       lines.push('### Architecture Hotspots (top files)');
       top.forEach(([f, c]) => lines.push(`- ${f}: ${c}`));
       lines.push('');
+    }
+    const examples = (cats.architecture || []).slice(0, Math.min(5, maxExamples));
+    if (examples.length) {
+      lines.push('### Examples');
+      for (const r of examples) {
+        lines.push(`- ${r.filePath}:${r.line || 0} ${r.ruleId} → ${r.message}`);
+        const snip = readSnippet(r.filePath, r.line, 2);
+        if (snip) {
+          lines.push('');
+          lines.push('```js');
+          lines.push(snip);
+          lines.push('```');
+          lines.push('');
+        }
+      }
     }
   }
 
@@ -148,7 +219,7 @@ function generateIssues(cwd, outDir, eslintJson /* array */, opts = {}) {
     writeJsonIndex(outPath, cats);
     return;
   }
-  writeMarkdownIssues(outPath, cats, { topFiles: opts.topFiles, minCount: opts.minCount });
+  writeMarkdownIssues(outPath, cats, { topFiles: opts.topFiles, minCount: opts.minCount, maxExamples: opts.maxExamples, cfg });
 }
 
 function generateInstructions(cwd, outDir, { includeCmd = 'github-cli', labels = 'lint,tech-debt' } = {}) {


### PR DESCRIPTION
Implements part of #146 for issues generation:

- Add Domain Hints to issue files when configured domain counts are all zero (guidance only; does not override configured domains)
- Include code snippets in Examples sections for terms/complexity/architecture in phase files
- Uses the same best-effort snippet logic as analysis (reads small context around the violation line)

No changes to CLI flags in this PR; relies on previously added thresholds (top-files/min-count) from PR #147.

Tests: full suite green (575 passing, 3 pending).