### PR TITLE
ci: publish 'lint-results.json' artifact

### DIFF
--- a/.github/workflows/lint-json-artifact.yml
+++ b/.github/workflows/lint-json-artifact.yml
@@ -1,0 +1,31 @@
+name: lint-json-artifact
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint-json:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint (JSON)
+        run: npm run lint:json
+
+      - name: Upload lint JSON artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-results-${{ github.sha }}
+          path: lint-results.json
+          if-no-files-found: error
+          retention-days: 7


### PR DESCRIPTION
Publishes the machine-readable ESLint output as a CI artifact.

- Runs `npm run lint:json` to generate `lint-results.json`
- Uploads `lint-results.json` as a build artifact (`actions/upload-artifact@v4`)
- Triggered on PRs and pushes to `main`

This supports downstream analysis and reproducibility for Issue #174.
