### PR TITLE
refactor(reporter): extract helpers; reduce writeAnalysisReport complexity/length; preserve output

### DIFF
--- a/lib/commands/analyze/reporter.js
+++ b/lib/commands/analyze/reporter.js
@@ -3,8 +3,38 @@
 const fs = require('fs');
 const path = require('path');
 
-function writeAnalysisReport(outPath, { categories, effort, returnString, topFiles = 10, minCount = 1, maxExamples = 5, cfg } = {}) {
-  const lines = [];
+// Helpers extracted to reduce complexity/length
+function byRule(list) {
+  const m = new Map();
+  for (const r of list || []) {
+    const key = String(r.ruleId || 'unknown');
+    m.set(key, (m.get(key) || 0) + 1);
+  }
+  return Array.from(m.entries()).sort((a, b) => b[1] - a[1]);
+}
+function topFilesFn(list, limit = 10, min = 1) {
+  const m = new Map();
+  for (const r of list || []) {
+    const k = String(r.filePath || 'unknown');
+    m.set(k, (m.get(k) || 0) + 1);
+  }
+  return Array.from(m.entries()).filter(([,c]) => c >= min).sort((a,b)=>b[1]-a[1]).slice(0, limit);
+}
+function sample(list, n = 5) { return (list || []).slice(0, n); }
+function readSnippet(filePath, line, context = 2) {
+  try {
+    const p = path.isAbsolute(filePath) ? filePath : path.join(process.cwd(), filePath);
+    const content = fs.readFileSync(p, 'utf8');
+    const rows = content.split(/\r?\n/);
+    const idx = Math.max(0, (Number(line) || 1) - 1);
+    const start = Math.max(0, idx - context);
+    const end = Math.min(rows.length, idx + context + 1);
+    return rows.slice(start, end).join('\n');
+  } catch (_) {
+    return null;
+  }
+}
+function pushHeader(lines, categories) {
   lines.push('# Analysis Report');
   lines.push('');
   lines.push(`Errors: ${categories.counts.errors}  Warnings: ${categories.counts.warnings}  Auto-fixable: ${categories.counts.autoFixable}`);
@@ -15,8 +45,8 @@ function writeAnalysisReport(outPath, { categories, effort, returnString, topFil
   lines.push(`- Domain terms: ${categories.domainTerms.length}`);
   lines.push(`- Architecture: ${categories.architecture.length}`);
   lines.push('');
-
-  // Configured domains (from .ai-coding-guide.json)
+}
+function pushConfiguredDomains(lines, cfg, categories) {
   const primary = cfg && cfg.domains && cfg.domains.primary;
   const additional = (cfg && cfg.domains && Array.isArray(cfg.domains.additional)) ? cfg.domains.additional : [];
   if (primary || (additional && additional.length)) {
@@ -24,84 +54,44 @@ function writeAnalysisReport(outPath, { categories, effort, returnString, topFil
     if (primary) lines.push(`- ${primary} (primary)`);
     for (const d of additional) lines.push(`- ${d} (additional)`);
     lines.push('');
-
-    // Summarize domain-term violations at a high level (no per-domain counts)
     lines.push('### Domain term violations');
     lines.push(`- Total: ${categories.domainTerms.length}`);
     lines.push('- See AGENTS.md for project terminology.');
     lines.push('');
   }
-
-  // Per-category breakdowns
-  function byRule(list) {
-    const m = new Map();
-    for (const r of list || []) {
-      const key = String(r.ruleId || 'unknown');
-      m.set(key, (m.get(key) || 0) + 1);
-    }
-    return Array.from(m.entries()).sort((a, b) => b[1] - a[1]);
+}
+function pushCategory(lines, name, list, topFiles, minCount, maxExamples) {
+  lines.push(`## ${name} (${list.length})`);
+  const rules = byRule(list);
+  if (rules.length) {
+    lines.push('### By rule');
+    rules.slice(0, 10).forEach(([rule, count]) => lines.push(`- ${rule}: ${count}`));
+    lines.push('');
   }
-  function topFilesFn(list, limit = 10, min = 1) {
-    const m = new Map();
-    for (const r of list || []) {
-      const k = String(r.filePath || 'unknown');
-      m.set(k, (m.get(k) || 0) + 1);
-    }
-    return Array.from(m.entries()).filter(([,c]) => c >= min).sort((a,b)=>b[1]-a[1]).slice(0, limit);
+  const files = topFilesFn(list, topFiles, minCount);
+  if (files.length) {
+    lines.push('### Top files');
+    files.forEach(([f, count]) => lines.push(`- ${f}: ${count}`));
+    lines.push('');
   }
-  function sample(list, n = 5) { return (list || []).slice(0, n); }
-  function readSnippet(filePath, line, context = 2) {
-    try {
-      const p = path.isAbsolute(filePath) ? filePath : path.join(process.cwd(), filePath);
-      const content = fs.readFileSync(p, 'utf8');
-      const rows = content.split(/\r?\n/);
-      const idx = Math.max(0, (Number(line) || 1) - 1);
-      const start = Math.max(0, idx - context);
-      const end = Math.min(rows.length, idx + context + 1);
-      return rows.slice(start, end).join('\n');
-    } catch (_) {
-      return null;
-    }
+  const examples = sample(list, maxExamples);
+  if (examples.length) {
+    lines.push('### Examples');
+    examples.forEach(r => {
+      lines.push(`- ${r.filePath}:${r.line || 0} ${r.ruleId} → ${r.message}`);
+      const snippet = readSnippet(r.filePath, r.line, 2);
+      if (snippet) {
+        lines.push('');
+        lines.push('```js');
+        lines.push(snippet);
+        lines.push('```');
+        lines.push('');
+      }
+    });
+    lines.push('');
   }
-
-  const sections = [
-    ['Complexity', categories.complexity],
-    ['Architecture', categories.architecture],
-    ['Domain terms', categories.domainTerms],
-    ['Magic numbers', categories.magicNumbers]
-  ];
-  for (const [name, list] of sections) {
-    lines.push(`## ${name} (${list.length})`);
-    const rules = byRule(list);
-    if (rules.length) {
-      lines.push('### By rule');
-      rules.slice(0, 10).forEach(([rule, count]) => lines.push(`- ${rule}: ${count}`));
-      lines.push('');
-    }
-    const files = topFilesFn(list, topFiles, minCount);
-    if (files.length) {
-      lines.push('### Top files');
-      files.forEach(([f, count]) => lines.push(`- ${f}: ${count}`));
-      lines.push('');
-    }
-    const examples = sample(list, maxExamples);
-    if (examples.length) {
-      lines.push('### Examples');
-      examples.forEach(r => {
-        lines.push(`- ${r.filePath}:${r.line || 0} ${r.ruleId} → ${r.message}`);
-        const snippet = readSnippet(r.filePath, r.line, 2);
-        if (snippet) {
-          lines.push('');
-          lines.push('```js');
-          lines.push(snippet);
-          lines.push('```');
-          lines.push('');
-        }
-      });
-      lines.push('');
-    }
-  }
-
+}
+function pushEffort(lines, effort) {
   lines.push('## Effort (rough estimate)');
   lines.push(`- Hours: ${effort.hours}`);
   lines.push(`- Days: ${effort.days}`);
@@ -115,6 +105,8 @@ function writeAnalysisReport(outPath, { categories, effort, returnString, topFil
     lines.push(`- Magic numbers: ${effort.byCategory.magicNumbers}`);
   }
   lines.push('');
+}
+function pushPrioritization(lines, categories, effort) {
   lines.push('## Prioritization (impact × effort heuristic)');
   const impact = [
     ['Complexity', categories.complexity.length, effort.byCategory?.complexity || 0],
@@ -125,9 +117,24 @@ function writeAnalysisReport(outPath, { categories, effort, returnString, topFil
   impact.sort((a, b) => (b[1] - a[1]) || (a[2] - b[2]));
   impact.forEach(([n, c, h]) => lines.push(`- ${n}: count=${c}, est=${h}h`));
   lines.push('');
-
   lines.push('Note: Domains are constrained to your configuration (domains.primary/additional).');
+}
 
+function writeAnalysisReport(outPath, { categories, effort, returnString, topFiles = 10, minCount = 1, maxExamples = 5, cfg } = {}) {
+  const lines = [];
+  pushHeader(lines, categories);
+  pushConfiguredDomains(lines, cfg, categories);
+  const sections = [
+    ['Complexity', categories.complexity],
+    ['Architecture', categories.architecture],
+    ['Domain terms', categories.domainTerms],
+    ['Magic numbers', categories.magicNumbers]
+  ];
+  for (const [name, list] of sections) {
+    pushCategory(lines, name, list, topFiles, minCount, maxExamples);
+  }
+  pushEffort(lines, effort);
+  pushPrioritization(lines, categories, effort);
   const content = lines.join('\n') + '\n';
   if (returnString) return content;
   fs.writeFileSync(outPath, content);


### PR DESCRIPTION
Phase 3A (complexity) — reporter.js refactor

What changed
- Extracted helpers from writeAnalysisReport to reduce complexity and function size:
  - byRule, topFilesFn, sample, readSnippet (module-level)
  - pushHeader, pushConfiguredDomains, pushCategory, pushEffort, pushPrioritization
- Behavior and output preserved; only orchestration refactor.

Analyzer deltas (current branch)
- complexity: 59 (±0)
- architecture: 58 (−1)
- magicNumbers: 0
- domainTerms: 0

Safety
- Tests: 599 passing, 3 pending
- Ratchet: OK (no increases)

Next steps
- Consider splitting category writers further if needed; proceed to categorize/categorizer.js next for larger reductions.
