### PR TITLE
refactor(analyze): reduce categorizeViolations complexity to <=10

### DIFF
--- a/lib/commands/analyze/categorizer.js
+++ b/lib/commands/analyze/categorizer.js
@@ -5,6 +5,71 @@ function push(map, key, item) {
   map[key].push(item);
 }
 
+// Classification helpers (reduce complexity in main function)
+function isMagicRule(rule) {
+  return rule.includes('no-redundant-calculations');
+}
+function isComplexityRule(rule) {
+  return rule === 'complexity' ||
+    rule.includes('prefer-simpler-logic') ||
+    rule.includes('no-equivalent-branches') ||
+    rule.includes('no-redundant-conditionals');
+}
+function isDomainTermsRule(rule) {
+  return rule.includes('enforce-domain-terms') || rule.includes('no-generic-names');
+}
+function isArchitectureRule(rule) {
+  return rule.includes('max-lines') ||
+    rule.includes('max-lines-per-function') ||
+    rule.includes('max-statements') ||
+    rule.includes('max-depth') ||
+    rule.includes('max-params');
+}
+
+function makeRec(filePath, m) {
+  return { filePath, message: m.message, ruleId: m.ruleId, line: m.line, column: m.column };
+}
+
+function tallyCounts(counts, m, usedFileFixable) {
+  if (m.severity === 2) counts.errors += 1; else counts.warnings += 1;
+  if (m.fix && !usedFileFixable) counts.autoFixable += 1;
+}
+
+// New helpers to reduce complexity further
+function addFileFixable(counts, f) {
+  const fileFixable = (f && ((f.fixableWarningCount || 0) + (f.fixableErrorCount || 0))) || 0;
+  if (fileFixable > 0) {
+    counts.autoFixable += fileFixable;
+    return true;
+  }
+  return false;
+}
+
+function routeRec(out, rule, rec) {
+  if (isMagicRule(rule)) {
+    push(out, 'magicNumbers', rec);
+  } else if (isComplexityRule(rule)) {
+    push(out, 'complexity', rec);
+  } else if (isDomainTermsRule(rule)) {
+    push(out, 'domainTerms', rec);
+  } else if (isArchitectureRule(rule)) {
+    push(out, 'architecture', rec);
+  }
+}
+
+function processMessage(out, f, m, usedFileFixable) {
+  const rule = String(m.ruleId || '').toLowerCase();
+  tallyCounts(out.counts, m, usedFileFixable);
+  const rec = makeRec(f.filePath, m);
+  routeRec(out, rule, rec);
+}
+
+function processFile(out, f) {
+  const usedFileFixable = addFileFixable(out.counts, f);
+  const messages = Array.isArray(f && f.messages) ? f.messages : [];
+  for (const m of messages) processMessage(out, f, m, usedFileFixable);
+}
+
 function categorizeViolations(eslintJson /* array */, cfg) {
   const out = {
     magicNumbers: [],
@@ -14,30 +79,7 @@ function categorizeViolations(eslintJson /* array */, cfg) {
     counts: { errors: 0, warnings: 0, autoFixable: 0 }
   };
   const files = Array.isArray(eslintJson) ? eslintJson : [];
-  for (const f of files) {
-    // Use file-level fixable counts when available for accurate totals
-    const fileFixable = (f && ((f.fixableWarningCount || 0) + (f.fixableErrorCount || 0))) || 0;
-    let usedFileFixable = false;
-    if (fileFixable > 0) {
-      out.counts.autoFixable += fileFixable;
-      usedFileFixable = true;
-    }
-    const messages = Array.isArray(f && f.messages) ? f.messages : [];
-    for (const m of messages) {
-      const rule = String(m.ruleId || '').toLowerCase();
-      if (m.severity === 2) out.counts.errors += 1; else out.counts.warnings += 1;
-      if (m.fix && !usedFileFixable) out.counts.autoFixable += 1;
-      const rec = { filePath: f.filePath, message: m.message, ruleId: m.ruleId, line: m.line, column: m.column };
-      const isMagic = rule.includes('no-redundant-calculations');
-      const isComplexity = rule === 'complexity' || rule.includes('prefer-simpler-logic') || rule.includes('no-equivalent-branches') || rule.includes('no-redundant-conditionals');
-      const isDomainTerms = rule.includes('enforce-domain-terms') || rule.includes('no-generic-names');
-      const isArch = rule.includes('max-lines') || rule.includes('max-lines-per-function') || rule.includes('max-statements') || rule.includes('max-depth') || rule.includes('max-params');
-      if (isMagic) push(out, 'magicNumbers', rec);
-      else if (isComplexity) push(out, 'complexity', rec);
-      else if (isDomainTerms) push(out, 'domainTerms', rec);
-      else if (isArch) push(out, 'architecture', rec);
-    }
-  }
+  for (const f of files) processFile(out, f);
   return out;
 }
 


### PR DESCRIPTION
Goal: micro-pass to drive categorizeViolations <=10 complexity.

Changes
- Extracted helpers to simplify the main function:
  - addFileFixable(counts, file)
  - routeRec(out, rule, rec)
  - processMessage(out, file, message, usedFileFixable)
  - processFile(out, file)
- categorizeViolations now orchestrates via processFile with minimal branching.
- No behavior changes: same output structure and counts.

Verification
- Tests: 599 passing, 3 pending.
- Ratchet: OK (no category increases).
- Analyzer: categorizeViolations no longer appears in complexity violations (was 27 previously; now < 10).

Notes
- Scoped commit only to lib/commands/analyze/categorizer.js.
- Avoided committing analysis-current.json and lint-results.json.

CI
- Pre-push hook ran lint → analyze → ratchet → tests successfully.
