### PR TITLE
refactor(init): extract helpers and flatten orchestration (Phase 3A)

### DIFF
--- a/lib/commands/init/index.js
+++ b/lib/commands/init/index.js
@@ -31,21 +31,26 @@ const { loadProjectConfigFile, deepMerge } = require(path.join(__dirname, '..', 
 const { shouldEnableArchitecture, normalizeBoolean } = require(path.join(__dirname, '..', '..', 'utils', 'arch-switch'));
 const { shouldEnableExternalConstants } = require(path.join(__dirname, '..', '..', 'utils', 'external-switch'));
 
-function initCommand(cwd, args) {
-  // Load existing config to preserve data from learn command
-  const { json: existingCfg } = loadProjectConfigFile(cwd);
-  
+// ===== Extracted helpers (keep orchestration thin) =====
+function parseDomainArgs(args) {
   const primary = (args.primary || 'general').trim();
   const additional = (args.additional || '').split(',').map(s => s.trim()).filter(Boolean);
-  const domainPriority = [primary, ...additional];
-const external = shouldEnableExternalConstants(args);
+  return { primary, additional, domainPriority: [primary, ...additional] };
+}
+
+function parseExternalArgs(args) {
+  const external = shouldEnableExternalConstants(args);
   const allowlist = (args.allowlist || '').split(',').map(s=>s.trim()).filter(Boolean);
   const minimumMatch = args.minimumMatch ? parseFloat(args.minimumMatch) : 0.6;
   const minimumConfidence = args.minimumConfidence ? parseFloat(args.minimumConfidence) : 0.7;
-  
-  // Create new config structure
-  // Note: Don't include antiPatterns here to preserve existing forbiddenNames from learn
-  const newCfg = {
+  return { external, allowlist, minimumMatch, minimumConfidence };
+}
+
+function createBaseConfig(domains, thresholds, externalCfg) {
+  const { primary, additional, domainPriority } = domains;
+  const { minimumMatch, minimumConfidence } = thresholds;
+  const { external, allowlist } = externalCfg;
+  return {
     domains: { primary, additional },
     domainPriority,
     constants: {},
@@ -56,94 +61,106 @@ const external = shouldEnableExternalConstants(args);
     experimentalExternalConstants: external,
     externalConstantsAllowlist: allowlist
   };
-  
-  // Merge with existing config to preserve learn command data
-  const cfg = deepMerge(existingCfg, newCfg);
-// Add architecture guardrails by default (disable with --no-arch or --arch=false)
+}
+
+function mergeWithExisting(cwd, newCfg) {
+  const { json: existingCfg } = loadProjectConfigFile(cwd);
+  return deepMerge(existingCfg, newCfg);
+}
+
+function applyArchitectureDefault(cfg, args) {
   const enableArch = shouldEnableArchitecture(args);
   if (enableArch) {
     const { DEFAULT_ARCHITECTURE } = require(path.join(__dirname, '..', '..', 'utils', 'arch-defaults'));
     cfg.architecture = JSON.parse(JSON.stringify(DEFAULT_ARCHITECTURE));
-  } else {
-    if (cfg && Object.prototype.hasOwnProperty.call(cfg, 'architecture')) delete cfg.architecture;
+  } else if (cfg && Object.prototype.hasOwnProperty.call(cfg, 'architecture')) {
+    delete cfg.architecture;
   }
-  // Merge fingerprint signals into config (domains + constantResolution)
-  applyFingerprintToConfig(cwd, cfg);
+  return enableArch;
+}
+
+function maybeWarnExternalWithoutAllowlist(external, allowlist) {
   if (external && (!allowlist || allowlist.length === 0)) {
     console.warn('Warning: --external used without allowlist; consider adding --allowlist to limit npm scope.');
   }
-  const code = writeConfig(cwd, cfg);
-  const hasWarp = fs.existsSync(path.join(cwd, 'WARP.md'));
-  // Cursor rules are opt-in only (do not enable with --yes)
-  if (args.cursor) writeCursorRules(cwd, cfg);
+}
 
-  // Defaults: generate AGENTS.md and ESLint config unless explicitly opted out
+function computeWriteTargets(args) {
   const disableAgents = Object.prototype.hasOwnProperty.call(args, 'no-agents') && normalizeBoolean(args['no-agents'], true);
   const disableEslint = Object.prototype.hasOwnProperty.call(args, 'no-eslint') && normalizeBoolean(args['no-eslint'], true);
   const explicitAgents = Object.prototype.hasOwnProperty.call(args, 'agents') ? normalizeBoolean(args.agents, true) : undefined;
   const explicitEslint = Object.prototype.hasOwnProperty.call(args, 'eslint') ? normalizeBoolean(args.eslint, true) : undefined;
   const shouldWriteAgents = disableAgents ? false : (explicitAgents === undefined ? true : explicitAgents);
   const shouldWriteEslint = disableEslint ? false : (explicitEslint === undefined ? true : explicitEslint);
+  return { disableAgents, disableEslint, shouldWriteAgents, shouldWriteEslint };
+}
 
-  // Informative note: --agents/--eslint are defaults now
-  if (args.agents && !disableAgents) {
-    console.log('Note: --agents is the default; this flag is no longer required.');
-  }
-  if (args.eslint && !disableEslint) {
-    console.log('Note: --eslint is the default; this flag is no longer required.');
-  }
+function maybeWriteDebugSnapshot(cwd, args, cfg, shouldWriteEslint, shouldWriteAgents, enableArch) {
+  try {
+    if (!(args && (args.debug || process.env.AI_DEBUG_INIT))) return;
+    const debugFile = path.join(cwd, '.ai-init-debug.json');
+    const eslintFileJs = path.join(cwd, 'eslint.config.js');
+    const eslintFileMjs = path.join(cwd, 'eslint.config.mjs');
+    const eslintFile = fs.existsSync(eslintFileMjs) ? eslintFileMjs : (fs.existsSync(eslintFileJs) ? eslintFileJs : null);
+    const eslintContent = eslintFile && fs.existsSync(eslintFile) ? fs.readFileSync(eslintFile, 'utf8') : '';
+    const agentsFile = path.join(cwd, 'AGENTS.md');
+    const agentsContent = fs.existsSync(agentsFile) ? fs.readFileSync(agentsFile, 'utf8') : '';
+    const snapshot = {
+      args: {
+        yes: !!args.yes,
+        eslint: normalizeBoolean(args.eslint, true),
+        noEslint: args['no-eslint'],
+        agents: normalizeBoolean(args.agents, true),
+        noAgents: args['no-agents'],
+        noArch: args['no-arch'],
+        arch: args.arch
+      },
+      argsRaw: args,
+      enableArchVar: enableArch,
+      enableArch: Boolean(!args['no-arch'] && args.arch && args.arch !== 'false'),
+      cfgHasArchitecture: !!cfg.architecture,
+      files: {
+        eslintConfig: eslintFile,
+        eslintHasGuardrails: Boolean(eslintContent && (/Architecture guardrails/.test(eslintContent) || /'max-lines'/.test(eslintContent))),
+        agentsMd: fs.existsSync(agentsFile),
+        agentsHasArchitectureSection: /## Architecture Guidelines/.test(agentsContent)
+      },
+      willWrite: { eslint: shouldWriteEslint, agents: shouldWriteAgents, cursor: !!args.cursor }
+    };
+    fs.writeFileSync(debugFile, JSON.stringify(snapshot, null, 2));
+  } catch { /* ignore debug write errors */ }
+}
+
+// ===== Orchestrators =====
+function initCommand(cwd, args) {
+  const domains = parseDomainArgs(args);
+  const ext = parseExternalArgs(args);
+  const newCfg = createBaseConfig(domains, { minimumMatch: ext.minimumMatch, minimumConfidence: ext.minimumConfidence }, { external: ext.external, allowlist: ext.allowlist });
+  const cfg = mergeWithExisting(cwd, newCfg);
+  const enableArch = applyArchitectureDefault(cfg, args);
+  applyFingerprintToConfig(cwd, cfg);
+  maybeWarnExternalWithoutAllowlist(ext.external, ext.allowlist);
+
+  const code = writeConfig(cwd, cfg);
+  const hasWarp = fs.existsSync(path.join(cwd, 'WARP.md'));
+
+  if (args.cursor) writeCursorRules(cwd, cfg);
+
+  const { disableAgents, disableEslint, shouldWriteAgents, shouldWriteEslint } = computeWriteTargets(args);
+
+  if (args.agents && !disableAgents) console.log('Note: --agents is the default; this flag is no longer required.');
+  if (args.eslint && !disableEslint) console.log('Note: --eslint is the default; this flag is no longer required.');
 
   if (shouldWriteAgents) {
     writeAgentsMd(cwd, cfg);
-    if (hasWarp) {
-      console.log('Found WARP.md — preserving it; generated AGENTS.md alongside.');
-    }
+    if (hasWarp) console.log('Found WARP.md — preserving it; generated AGENTS.md alongside.');
   }
   if (shouldWriteEslint) writeEslintConfig(cwd, cfg);
 
-  // Post-init guidance
   console.log('\nProject initialized.');
   printRatchetNextSteps();
 
-  // Optional debug snapshot to aid CI investigation
-  try {
-    if (args.debug || process.env.AI_DEBUG_INIT) {
-      const debugFile = path.join(cwd, '.ai-init-debug.json');
-      const eslintFileJs = path.join(cwd, 'eslint.config.js');
-      const eslintFileMjs = path.join(cwd, 'eslint.config.mjs');
-      const eslintFile = fs.existsSync(eslintFileMjs) ? eslintFileMjs : (fs.existsSync(eslintFileJs) ? eslintFileJs : null);
-      const eslintContent = eslintFile && fs.existsSync(eslintFile) ? fs.readFileSync(eslintFile, 'utf8') : '';
-      const agentsFile = path.join(cwd, 'AGENTS.md');
-      const agentsContent = fs.existsSync(agentsFile) ? fs.readFileSync(agentsFile, 'utf8') : '';
-      const snapshot = {
-        args: {
-          yes: !!args.yes,
-          eslint: normalizeBoolean(args.eslint, true),
-          noEslint: args['no-eslint'],
-          agents: normalizeBoolean(args.agents, true),
-          noAgents: args['no-agents'],
-          noArch: args['no-arch'],
-          arch: args.arch
-        },
-        argsRaw: args,
-        enableArchVar: enableArch,
-        enableArch: Boolean(!args['no-arch'] && args.arch && args.arch !== 'false'),
-        cfgHasArchitecture: !!cfg.architecture,
-        files: {
-          eslintConfig: eslintFile,
-          eslintHasGuardrails: Boolean(eslintContent && (/Architecture guardrails/.test(eslintContent) || /'max-lines'/.test(eslintContent))),
-          agentsMd: fs.existsSync(agentsFile),
-          agentsHasArchitectureSection: /## Architecture Guidelines/.test(agentsContent)
-        },
-        willWrite: {
-          eslint: shouldWriteEslint,
-          agents: shouldWriteAgents,
-          cursor: !!args.cursor
-        }
-      };
-      fs.writeFileSync(debugFile, JSON.stringify(snapshot, null, 2));
-    }
-  } catch { /* ignore debug write errors */ }
+  maybeWriteDebugSnapshot(cwd, args, cfg, shouldWriteEslint, shouldWriteAgents, enableArch);
 
   return code;
 }
@@ -152,12 +169,12 @@ async function initInteractiveCommand(cwd, args) {
   const readline = require('readline');
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   try {
+    // Prompt primary domain
     let primary = (await ask(rl, 'Primary domain (default: general): ')).trim() || 'general';
     const suggested = suggestFor(primary);
-    if (suggested.length) {
-      console.log(`Suggested additional domains for ${primary}: ${suggested.join(', ')}`);
-    }
-    // Show domain metadata via wizard helper
+    if (suggested.length) console.log(`Suggested additional domains for ${primary}: ${suggested.join(', ')}`);
+
+    // Wizard metadata (best-effort)
     try {
       const { buildDomainMetadata } = require(path.join(__dirname, '..', '..', 'wizard', 'domain-selector'));
       const metas = buildDomainMetadata();
@@ -168,17 +185,15 @@ async function initInteractiveCommand(cwd, args) {
           console.log(`  - ${m.name} (constants: ${m.constantsCount}, terms: ${m.termsCount}, sources: ${src})`);
         }
         const sel = metas.find(d => d.name === primary);
-        if (sel && sel.constantsCount === 0) {
-          console.warn(`⚠️ Warning: selected primary '${primary}' has zero discovered constants.`);
-        }
+        if (sel && sel.constantsCount === 0) console.warn(`⚠️ Warning: selected primary '${primary}' has zero discovered constants.`);
       }
-    } catch { /* ignore wizard metadata errors */ }
+    } catch { /* ignore */ }
+
+    // Additional domains
     let addAns = (await ask(rl, 'Additional domains (comma-separated, optional): ')).trim();
 
-    // Optional: interactive external discovery listing
-    // Keep interactive external discovery prompts gated behind an explicit flag to avoid changing prompt flow by default
-    const externalPromptEnabled = (args && (Object.prototype.hasOwnProperty.call(args, 'external') || Object.prototype.hasOwnProperty.call(args, 'experimentalExternalConstants')))
-      && shouldEnableExternalConstants(args || {});
+    // Optional experimental external discovery flow (opt-in via flags)
+    const externalPromptEnabled = (args && (Object.prototype.hasOwnProperty.call(args, 'external') || Object.prototype.hasOwnProperty.call(args, 'experimentalExternalConstants'))) && shouldEnableExternalConstants(args || {});
     if (externalPromptEnabled) {
       try {
         const { discoverConstants } = require(path.join(__dirname, '..', '..', 'utils', 'discover-constants'));
@@ -197,11 +212,8 @@ async function initInteractiveCommand(cwd, args) {
           const priPick = (await ask(rl, 'Pick primary by name or index (Enter to keep): ')).trim();
           if (priPick) {
             const idx = Number(priPick);
-            if (Number.isInteger(idx) && idx>=1 && idx<=domainList.length) {
-              primary = domainList[idx-1];
-            } else if (domainList.includes(priPick)) {
-              primary = priPick;
-            }
+            if (Number.isInteger(idx) && idx>=1 && idx<=domainList.length) primary = domainList[idx-1];
+            else if (domainList.includes(priPick)) primary = priPick;
           }
           const addPick = (await ask(rl, 'Pick additional (comma-separated names or indices, Enter to keep): ')).trim();
           if (addPick) {
@@ -219,25 +231,21 @@ async function initInteractiveCommand(cwd, args) {
         console.warn(`(external discovery skipped: ${err && err.message})`);
       }
     }
+
     const additional = addAns ? addAns.split(',').map(s=>s.trim()).filter(Boolean) : [];
     const domainPriority = [primary, ...additional];
     console.log(`\nSummary:\n  primary: ${primary}\n  additional: ${additional.join(', ') || '(none)'}\n  domainPriority: ${domainPriority.join(', ')}`);
-    
+
     // Architecture guardrails prompt
     const { promptArchitectureGuardrails } = require(path.join(__dirname, '..', '..', 'wizard', 'arch-prompts'));
     const architecture = await promptArchitectureGuardrails(rl, ask);
-    
+
+    // Confirm
     const confirm = (await ask(rl, '\nWrite .ai-coding-guide.json with these settings? (Y/n): ')).trim().toLowerCase();
-    if (confirm && confirm.startsWith('n')) {
-      console.log('Aborted.');
-      return 1;
-    }
-    
-    // Load existing config to preserve data from learn command
+    if (confirm && confirm.startsWith('n')) { console.log('Aborted.'); return 1; }
+
+    // Merge + write
     const { json: existingCfg } = loadProjectConfigFile(cwd);
-    
-    // Create new config structure
-    // Note: Don't include antiPatterns here to preserve existing forbiddenNames from learn
     const newCfg = {
       domains: { primary, additional },
       domainPriority,
@@ -245,27 +253,23 @@ async function initInteractiveCommand(cwd, args) {
       terms: { entities: [], properties: [], actions: [] },
       naming: { style: 'camelCase', booleanPrefix: ['is','has','should','can'], asyncPrefix: ['fetch','load','save'], pluralizeCollections: true }
     };
-    
-    // Merge with existing config to preserve learn command data
     const cfg = deepMerge(existingCfg, newCfg);
-    if (architecture) {
-      cfg.architecture = architecture;
-    }
+    if (architecture) cfg.architecture = architecture;
+
     const code = writeConfig(cwd, cfg);
+
     const genCursor = (await ask(rl, 'Generate .cursorrules? (Y/n): ')).trim().toLowerCase();
-    if (!genCursor || genCursor.startsWith('y')) {
-      writeCursorRules(cwd, cfg);
-    }
+    if (!genCursor || genCursor.startsWith('y')) writeCursorRules(cwd, cfg);
+
     const hasWarp = fs.existsSync(path.join(cwd, 'WARP.md'));
     console.log(hasWarp ? 'Detected WARP.md — will not modify it.' : 'No WARP.md detected.');
+
     const agents = (await ask(rl, 'Generate AGENTS.md (recommended)? (Y/n): ')).trim().toLowerCase();
-    if (!agents || agents.startsWith('y')) {
-      writeAgentsMd(cwd, cfg);
-    }
+    if (!agents || agents.startsWith('y')) writeAgentsMd(cwd, cfg);
+
     const genEslint = (await ask(rl, 'Generate eslint.config.mjs (Y/n): ')).trim().toLowerCase();
-    if (!genEslint || genEslint.startsWith('y')) {
-      writeEslintConfig(cwd, cfg);
-    }
+    if (!genEslint || genEslint.startsWith('y')) writeEslintConfig(cwd, cfg);
+
     console.log('\nProject initialized.');
     printRatchetNextSteps();
     return code;


### PR DESCRIPTION
Phase 3A: init refactor to reduce complexity by extracting small helpers and flattening init orchestration.

Changes
- Added helpers in lib/commands/init/index.js:
  - parseDomainArgs(args)
  - parseExternalArgs(args)
  - createBaseConfig(domains, thresholds, externalCfg)
  - mergeWithExisting(cwd, newCfg)
  - applyArchitectureDefault(cfg, args)
  - computeWriteTargets(args)
  - maybeWarnExternalWithoutAllowlist(external, allowlist)
  - maybeWriteDebugSnapshot(cwd, args, cfg, shouldWriteEslint, shouldWriteAgents, enableArch)
- initCommand now orchestrates via these helpers (no behavior changes).
- initInteractiveCommand lightly flattened (no prompt flow changes).

Verification
- Tests: 599 passing, 3 pending.
- Ratchet: OK (no increases).
- Analyzer: initCommand complexity reduced (targeting ≤10 in subsequent micro-passes if needed).

Notes
- No file moves yet; keeping helpers in-file for minimal risk. Further splits to subfiles can proceed under Phase 3B.
