### PR TITLE
refactor(rules): lower complexity in enforce-domain-terms and no-equivalent-branches (Phase 3A)

### DIFF
--- a/lib/rules/enforce-domain-terms.js
+++ b/lib/rules/enforce-domain-terms.js
@@ -26,44 +26,59 @@ function hasDomainTerm(name, terms) {
   return false;
 }
 
-function collectDomainTerms(project, options) {
-  const opt = options && options[0] ? options[0] : {};
-  const fromOptions = Array.isArray(opt.requiredTerms) ? opt.requiredTerms : [];
+function getPriorityDomains(project) {
+  if (Array.isArray(project && project.domainPriority) && project.domainPriority.length) {
+    return project.domainPriority;
+  }
+  const primary = project && project.domains && project.domains.primary;
+  const addl = (project && project.domains && project.domains.additional) || [];
+  return primary ? [primary, ...addl] : [];
+}
 
-  // Priority: active domains -> project terms/options
-  const priorityDomains = Array.isArray(project?.domainPriority) && project.domainPriority.length
-    ? project.domainPriority
-    : (project?.domains?.primary ? [project.domains.primary, ...(project?.domains?.additional || [])] : []);
-
-  const priorityTerms = [];
+function collectDomainTermsFromDomains(priorityDomains) {
+  const out = [];
   for (const d of priorityDomains) {
     const mod = DOMAINS && DOMAINS[d];
     if (mod && Array.isArray(mod.terms)) {
-      for (const t of mod.terms) priorityTerms.push(String(t));
+      for (const t of mod.terms) out.push(String(t));
     }
   }
+  return out;
+}
 
-  const terms = new Set();
-  for (const t of priorityTerms) terms.add(t);
-  for (const t of fromOptions) terms.add(String(t));
-
-  const cfg = project && project.terms ? project.terms : {};
+function mergeProjectAndOptionTerms(termsSet, project, fromOptions) {
+  for (const t of fromOptions) termsSet.add(String(t));
+  const cfg = (project && project.terms) || {};
   const buckets = [cfg.entities || [], cfg.properties || [], cfg.actions || [], cfg.preferredNames || []];
   for (const bucket of buckets) {
     if (!Array.isArray(bucket)) continue;
-    for (const t of bucket) terms.add(String(t));
+    for (const t of bucket) termsSet.add(String(t));
   }
+}
+
+function collectDomainTerms(project, options) {
+  const opt = options && options[0] ? options[0] : {};
+  const fromOptions = Array.isArray(opt.requiredTerms) ? opt.requiredTerms : [];
+  const priorityDomains = getPriorityDomains(project);
+  const priorityTerms = collectDomainTermsFromDomains(priorityDomains);
+  const terms = new Set(priorityTerms);
+  mergeProjectAndOptionTerms(terms, project, fromOptions);
   return Array.from(terms).filter(Boolean);
+}
+
+function addAll(set, arr) {
+  if (!Array.isArray(arr)) return;
+  for (const n of arr) set.add(String(n));
 }
 
 function collectExemptions(project, options) {
   const opt = options && options[0] ? options[0] : {};
   const out = new Set();
-  for (const n of opt.exemptNames || []) out.add(String(n));
-  const cfg = project && project.terms ? project.terms : {};
-  for (const n of cfg.exemptNames || []) out.add(String(n));
-  const naming = project && project.naming ? project.naming : {};
-  for (const n of naming.exemptNames || []) out.add(String(n));
+  addAll(out, opt.exemptNames || []);
+  const cfg = (project && project.terms) || {};
+  addAll(out, cfg.exemptNames || []);
+  const naming = (project && project.naming) || {};
+  addAll(out, naming.exemptNames || []);
   return out;
 }
 

--- a/lib/rules/no-equivalent-branches.js
+++ b/lib/rules/no-equivalent-branches.js
@@ -14,71 +14,51 @@
  * @param {ASTNode} node2 - Second node to compare
  * @returns {boolean} - True if nodes are structurally equivalent
  */
+const _comparators = {
+  Literal(a, b) { return a.value === b.value; },
+  Identifier(a, b) { return a.name === b.name; },
+  MemberExpression(a, b) {
+    return areNodesEquivalent(a.object, b.object) &&
+      areNodesEquivalent(a.property, b.property) &&
+      a.computed === b.computed;
+  },
+  CallExpression(a, b) {
+    return areNodesEquivalent(a.callee, b.callee) &&
+      a.arguments.length === b.arguments.length &&
+      a.arguments.every((arg, i) => areNodesEquivalent(arg, b.arguments[i]));
+  },
+  BinaryExpression(a, b) {
+    return a.operator === b.operator && areNodesEquivalent(a.left, b.left) && areNodesEquivalent(a.right, b.right);
+  },
+  LogicalExpression(a, b) {
+    return _comparators.BinaryExpression(a, b);
+  },
+  UnaryExpression(a, b) {
+    return a.operator === b.operator && areNodesEquivalent(a.argument, b.argument);
+  },
+  ReturnStatement(a, b) { return areNodesEquivalent(a.argument, b.argument); },
+  ExpressionStatement(a, b) { return areNodesEquivalent(a.expression, b.expression); },
+  AssignmentExpression(a, b) {
+    return a.operator === b.operator && areNodesEquivalent(a.left, b.left) && areNodesEquivalent(a.right, b.right);
+  },
+  VariableDeclaration(a, b) {
+    return a.kind === b.kind && a.declarations.length === b.declarations.length &&
+      a.declarations.every((decl, i) => areNodesEquivalent(decl, b.declarations[i]));
+  },
+  VariableDeclarator(a, b) {
+    return areNodesEquivalent(a.id, b.id) && areNodesEquivalent(a.init, b.init);
+  },
+  BlockStatement(a, b) {
+    return a.body.length === b.body.length && a.body.every((stmt, i) => areNodesEquivalent(stmt, b.body[i]));
+  }
+};
+
 function areNodesEquivalent(node1, node2) {
-  if (!node1 || !node2) {
-    return node1 === node2;
-  }
-
-  if (node1.type !== node2.type) {
-    return false;
-  }
-
-  // Compare based on node type
-  switch (node1.type) {
-    case 'Literal':
-      return node1.value === node2.value;
-
-    case 'Identifier':
-      return node1.name === node2.name;
-
-    case 'MemberExpression':
-      return areNodesEquivalent(node1.object, node2.object) &&
-             areNodesEquivalent(node1.property, node2.property) &&
-             node1.computed === node2.computed;
-
-    case 'CallExpression':
-      return areNodesEquivalent(node1.callee, node2.callee) &&
-             node1.arguments.length === node2.arguments.length &&
-             node1.arguments.every((arg, i) => areNodesEquivalent(arg, node2.arguments[i]));
-
-    case 'BinaryExpression':
-    case 'LogicalExpression':
-      return node1.operator === node2.operator &&
-             areNodesEquivalent(node1.left, node2.left) &&
-             areNodesEquivalent(node1.right, node2.right);
-
-    case 'UnaryExpression':
-      return node1.operator === node2.operator &&
-             areNodesEquivalent(node1.argument, node2.argument);
-
-    case 'ReturnStatement':
-      return areNodesEquivalent(node1.argument, node2.argument);
-
-    case 'ExpressionStatement':
-      return areNodesEquivalent(node1.expression, node2.expression);
-
-    case 'AssignmentExpression':
-      return node1.operator === node2.operator &&
-             areNodesEquivalent(node1.left, node2.left) &&
-             areNodesEquivalent(node1.right, node2.right);
-
-    case 'VariableDeclaration':
-      return node1.kind === node2.kind &&
-             node1.declarations.length === node2.declarations.length &&
-             node1.declarations.every((decl, i) => areNodesEquivalent(decl, node2.declarations[i]));
-
-    case 'VariableDeclarator':
-      return areNodesEquivalent(node1.id, node2.id) &&
-             areNodesEquivalent(node1.init, node2.init);
-
-    case 'BlockStatement':
-      return node1.body.length === node2.body.length &&
-             node1.body.every((stmt, i) => areNodesEquivalent(stmt, node2.body[i]));
-
-    default:
-      // For other node types, use source code comparison
-      return false;
-  }
+  if (!node1 || !node2) return node1 === node2;
+  if (node1.type !== node2.type) return false;
+  const cmp = _comparators[node1.type];
+  if (!cmp) return false;
+  return cmp(node1, node2);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Phase 3A: Reduce complexity in key rule hotspots without behavior changes.

Rules touched
- enforce-domain-terms.js
  - collectDomainTerms: split into helpers (getPriorityDomains, collectDomainTermsFromDomains, mergeProjectAndOptionTerms)
  - collectExemptions: split addAll helper; simplified
- no-equivalent-branches.js
  - areNodesEquivalent: replaced large switch with table-driven _comparators map; kept semantics identical

Verification
- Tests: 599 passing, 3 pending.
- Ratchet: OK (no complexity/architecture increases).
- Analyzer: removes two high-complexity offenders by breaking into ≤10-complexity helpers.

Notes
- Pure refactors; no rule messages/behavior changed.
- Further rule hotspots remain (no-redundant-conditionals*, etc.) and can be addressed next.
