### PR TITLE
refactor(rule): no-redundant-conditionals complexity reductions (Phase 3A)

### DIFF
--- a/lib/rules/no-redundant-conditionals.js
+++ b/lib/rules/no-redundant-conditionals.js
@@ -118,42 +118,27 @@ module.exports = {
      */
     function isRedundantBooleanComparison(node) {
       if (node.type !== 'BinaryExpression') return null;
-
       const { operator, left, right } = node;
-      const isBoolLiteral = (n, val) => n.type === 'Literal' && typeof n.value === 'boolean' && n.value === val;
-      
-      // Only consider comparisons with boolean literals
-      // x === true, x == true → x
-      if ((operator === '===' || operator === '==') && isBoolLiteral(right, true)) {
-        return { node: left, negated: false, strict: operator === '===' };
-      }
-      if ((operator === '===' || operator === '==') && isBoolLiteral(left, true)) {
-        return { node: right, negated: false, strict: operator === '===' };
-      }
+      const isBoolLit = (n) => n.type === 'Literal' && typeof n.value === 'boolean';
+      const strict = operator === '===' || operator === '!==' ;
+      const isEq = operator === '===' || operator === '==';
+      const isNe = operator === '!==' || operator === '!=';
 
-      // x !== false, x != false → x
-      if ((operator === '!==' || operator === '!=') && isBoolLiteral(right, false)) {
-        return { node: left, negated: false, strict: operator === '!==' };
-      }
-      if ((operator === '!==' || operator === '!=') && isBoolLiteral(left, false)) {
-        return { node: right, negated: false, strict: operator === '!==' };
-      }
+      // Helper to build result consistently
+      function res(target, neg) { return { node: target, negated: neg, strict }; }
 
-      // x === false, x == false → !x
-      if ((operator === '===' || operator === '==') && isBoolLiteral(right, false)) {
-        return { node: left, negated: true, strict: operator === '===' };
-      }
-      if ((operator === '===' || operator === '==') && isBoolLiteral(left, false)) {
-        return { node: right, negated: true, strict: operator === '===' };
-      }
+      // Pattern matrix (check right then left to stay symmetric)
+      if (isEq && isBoolLit(right) && right.value === true) return res(left, false);
+      if (isEq && isBoolLit(left) && left.value === true) return res(right, false);
 
-      // x !== true, x != true → !x
-      if ((operator === '!==' || operator === '!=') && isBoolLiteral(right, true)) {
-        return { node: left, negated: true, strict: operator === '!==' };
-      }
-      if ((operator === '!==' || operator === '!=') && isBoolLiteral(left, true)) {
-        return { node: right, negated: true, strict: operator === '!==' };
-      }
+      if (isNe && isBoolLit(right) && right.value === false) return res(left, false);
+      if (isNe && isBoolLit(left) && left.value === false) return res(right, false);
+
+      if (isEq && isBoolLit(right) && right.value === false) return res(left, true);
+      if (isEq && isBoolLit(left) && left.value === false) return res(right, true);
+
+      if (isNe && isBoolLit(right) && right.value === true) return res(left, true);
+      if (isNe && isBoolLit(left) && left.value === true) return res(right, true);
 
       return null;
     }
@@ -164,6 +149,51 @@ module.exports = {
 
     // Simplify logical expressions in conditions when safe
     // Evaluate constant value of an expression, or null if unknown
+    function evalUnaryOp(op, v) {
+      if (v === null) return null;
+      if (op === '-') return typeof v === 'number' ? -v : null;
+      if (op === '+') return typeof v === 'number' ? +v : null;
+      if (op === '!') return !v;
+      return null;
+    }
+
+    function evalNumberOp(op, l, r) {
+      if (op === '-') return l - r;
+      if (op === '*') return l * r;
+      if (op === '/') return l / r;
+      if (op === '%') return l % r;
+      if (op === '**') return l ** r;
+      return NaN;
+    }
+
+    function evalRelOp(op, l, r) {
+      if (op === '<') return l < r;
+      if (op === '>') return l > r;
+      if (op === '<=') return l <= r;
+      if (op === '>=') return l >= r;
+      return false;
+    }
+
+    function evalBinaryOp(op, l, r) {
+      if (l === null || r === null) return null;
+      if (op === '+') {
+        if (typeof l === 'number' && typeof r === 'number') return l + r;
+        if (typeof l === 'string' || typeof r === 'string') return String(l) + String(r);
+        return null;
+      }
+      if (op === '-' || op === '*' || op === '/' || op === '%' || op === '**') {
+        if (typeof l === 'number' && typeof r === 'number') return evalNumberOp(op, l, r);
+        return null;
+      }
+      if (op === '<' || op === '>' || op === '<=' || op === '>=') {
+        if (typeof l === 'number' && typeof r === 'number') return evalRelOp(op, l, r);
+        return null;
+      }
+      if (op === '===') return l === r;
+      if (op === '!==') return l !== r;
+      return null;
+    }
+
     function evaluateConstant(node) {
       if (node.type === 'Literal') return node.value;
       if (node.type === 'Identifier') {
@@ -173,116 +203,63 @@ module.exports = {
       }
       if (node.type === 'UnaryExpression') {
         const v = evaluateConstant(node.argument);
-        if (v === null) return null;
-        switch (node.operator) {
-          case '-': return typeof v === 'number' ? -v : null;
-          case '+': return typeof v === 'number' ? +v : null;
-          case '!': return !v;
-          default: return null;
-        }
+        return evalUnaryOp(node.operator, v);
       }
       if (node.type === 'BinaryExpression') {
         const l = evaluateConstant(node.left);
         const r = evaluateConstant(node.right);
-        if (l === null || r === null) return null;
-        switch (node.operator) {
-          case '+':
-            if (typeof l === 'number' && typeof r === 'number') return l + r;
-            if (typeof l === 'string' || typeof r === 'string') return String(l) + String(r);
-            return null;
-          case '-': case '*': case '/': case '%': case '**':
-            if (typeof l === 'number' && typeof r === 'number') return evalNumberOp(node.operator, l, r);
-            return null;
-          case '<': case '>': case '<=': case '>=':
-            if (typeof l === 'number' && typeof r === 'number') return evalRelOp(node.operator, l, r);
-            return null;
-          case '===': return l === r;
-          case '!==': return l !== r;
-          default: return null;
-        }
+        return evalBinaryOp(node.operator, l, r);
       }
       return null;
     }
 
-    function evalNumberOp(op, l, r) {
-      switch (op) {
-        case '-': return l - r;
-        case '*': return l * r;
-        case '/': return l / r;
-        case '%': return l % r;
-        case '**': return l ** r;
-        default: return NaN;
-      }
+    function triBool(node) {
+      const raw = getBooleanValue(node);
+      if (node.type === 'Identifier' && node.name !== 'undefined' && node.name !== 'NaN') return null;
+      return raw;
     }
 
-    function evalRelOp(op, l, r) {
-      switch (op) {
-        case '<': return l < r;
-        case '>': return l > r;
-        case '<=': return l <= r;
-        case '>=': return l >= r;
-        default: return false;
-      }
+    function constantFixBuilder(sourceCode, node, value) {
+      return function(fixer) {
+        if (value) {
+          if (node.consequent.type === 'BlockStatement') {
+            const bodyText = sourceCode.getText(node.consequent).slice(1, -1).trim();
+            return fixer.replaceText(node, bodyText);
+          }
+          return fixer.replaceText(node, sourceCode.getText(node.consequent));
+        }
+        if (node.alternate) {
+          if (node.alternate.type === 'BlockStatement') {
+            const altText = sourceCode.getText(node.alternate).slice(1, -1).trim();
+            return fixer.replaceText(node, altText);
+          }
+          return fixer.replaceText(node, sourceCode.getText(node.alternate));
+        }
+        return fixer.remove(node);
+      };
     }
 
     function simplifyLogicalExpression(test, node) {
       if (test.type !== 'LogicalExpression') return null;
-      const rawLeftVal = getBooleanValue(test.left);
-      const rawRightVal = getBooleanValue(test.right);
-      // Treat non-special identifiers as unknown (null), regardless of heuristic boolean value
-      const leftVal = (test.left.type === 'Identifier' && test.left.name !== 'undefined' && test.left.name !== 'NaN') ? null : rawLeftVal;
-      const rightVal = (test.right.type === 'Identifier' && test.right.name !== 'undefined' && test.right.name !== 'NaN') ? null : rawRightVal;
+      const leftVal = triBool(test.left);
+      const rightVal = triBool(test.right);
       const op = test.operator;
       const leftText = sourceCode.getText(test.left);
       const rightText = sourceCode.getText(test.right);
 
-      // Helper to build constant-condition style fix
-      function constantFix(value) {
-        return function(fixer) {
-          if (value) {
-            if (node.consequent.type === 'BlockStatement') {
-              const bodyText = sourceCode.getText(node.consequent).slice(1, -1).trim();
-              return fixer.replaceText(node, bodyText);
-            }
-            return fixer.replaceText(node, sourceCode.getText(node.consequent));
-          }
-          if (node.alternate) {
-            if (node.alternate.type === 'BlockStatement') {
-              const altText = sourceCode.getText(node.alternate).slice(1, -1).trim();
-              return fixer.replaceText(node, altText);
-            }
-            return fixer.replaceText(node, sourceCode.getText(node.alternate));
-          }
-          return fixer.remove(node);
-        };
-      }
-
-      // Evaluate simplifications
       if (op === '&&') {
-        // Constant false if either side is known false
         if (leftVal === false || rightVal === false) {
-          return { kind: 'constant', value: false, fix: constantFix(false) };
+          return { kind: 'constant', value: false, fix: constantFixBuilder(sourceCode, node, false) };
         }
-        // Simplify when one side is known true and the other is unknown
-        if (leftVal === true && rightVal === null) {
-          return { kind: 'expr', text: rightText };
-        }
-        if (rightVal === true && leftVal === null) {
-          return { kind: 'expr', text: leftText };
-        }
+        if (leftVal === true && rightVal === null) return { kind: 'expr', text: rightText };
+        if (rightVal === true && leftVal === null) return { kind: 'expr', text: leftText };
       }
       if (op === '||') {
-        // Constant true if either side is known true
         if (leftVal === true || rightVal === true) {
-          return { kind: 'constant', value: true, fix: constantFix(true) };
+          return { kind: 'constant', value: true, fix: constantFixBuilder(sourceCode, node, true) };
         }
-        // Simplify when one side is known false and the other is unknown
-        if (leftVal === false && rightVal === null) {
-          return { kind: 'expr', text: rightText };
-        }
-        if (rightVal === false && leftVal === null) {
-          return { kind: 'expr', text: leftText };
-        }
+        if (leftVal === false && rightVal === null) return { kind: 'expr', text: rightText };
+        if (rightVal === false && leftVal === null) return { kind: 'expr', text: leftText };
       }
       return null;
     }


### PR DESCRIPTION
Phase 3A: Refactor no-redundant-conditionals to reduce cyclomatic complexity while preserving behavior.

Changes
- Extracted operator helpers:
  - evalUnaryOp(op, v)
  - evalNumberOp(op, l, r)
  - evalRelOp(op, l, r)
  - evalBinaryOp(op, l, r)
- Simplified boolean comparison detection via a small decision matrix in isRedundantBooleanComparison.
- Extracted triBool() and constantFixBuilder() and simplified simplifyLogicalExpression().

Verification
- Tests: 599 passing, 3 pending.
- Ratchet: OK (no increases).
- Analyzer: reduces complexity in evaluateConstant (35 → ≤10 path), isRedundantBooleanComparison (26 → ≤10), simplifyLogicalExpression (22 → ≤10).

Notes
- Pure refactor; rule behavior and messages unchanged.
- Further opportunities remain in other rule files.
