### PR TITLE
refactor(analyze): reduce estimator complexity (Phase 3A)

### DIFF
--- a/lib/commands/analyze/estimator.js
+++ b/lib/commands/analyze/estimator.js
@@ -43,6 +43,41 @@ function fileSizeFactor(lines) {
   return factor;
 }
 
+// ===== Extracted helpers to reduce complexity =====
+function computeBaseWeight(ruleId) {
+  const rule = String(ruleId || '').toLowerCase();
+  return RULE_WEIGHTS.get(rule) ?? DEFAULT_RULE_WEIGHT;
+}
+
+function getCachedLines(cwd, filePath, cache) {
+  if (!filePath) return null;
+  if (cache.has(filePath)) return cache.get(filePath);
+  const lines = getFileLinesCount(cwd, filePath);
+  cache.set(filePath, lines);
+  return lines;
+}
+
+function weightForRecord(rec, opts, cache) {
+  let weight = computeBaseWeight(rec.ruleId);
+  if (opts.useFileSize && rec.filePath) {
+    const lines = getCachedLines(opts.cwd, rec.filePath, cache);
+    weight *= fileSizeFactor(lines);
+  }
+  return weight;
+}
+
+function accumulate(cat, rec, state, opts) {
+  const w = weightForRecord(rec, opts, state.fileLinesCache);
+  state.byCategoryHours[cat] += w;
+  state.totalHours += w;
+}
+
+function toDurations(totalHours) {
+  const days = totalHours / 8;
+  const weeks = days / 5;
+  return { hours: round1(totalHours), days: round1(days), weeks: round1(weeks) };
+}
+
 function estimateEffort(categories, { cwd = process.cwd(), useFileSize = false } = {}) {
   const c = categories || {};
   const lists = [
@@ -52,39 +87,25 @@ function estimateEffort(categories, { cwd = process.cwd(), useFileSize = false }
     ['complexity', c.complexity || []]
   ];
 
-  const fileLinesCache = new Map();
-  const byCategoryHours = { magicNumbers: 0, domainTerms: 0, architecture: 0, complexity: 0 };
-  let totalHours = 0;
+  const state = {
+    fileLinesCache: new Map(),
+    byCategoryHours: { magicNumbers: 0, domainTerms: 0, architecture: 0, complexity: 0 },
+    totalHours: 0
+  };
+  const opts = { cwd, useFileSize };
 
   for (const [cat, arr] of lists) {
-    for (const rec of arr) {
-      const rule = String(rec.ruleId || '').toLowerCase();
-      const base = RULE_WEIGHTS.get(rule) ?? DEFAULT_RULE_WEIGHT;
-      let weight = base;
-      if (useFileSize && rec.filePath) {
-        let lines = fileLinesCache.get(rec.filePath);
-        if (lines === null || lines === undefined) {
-          lines = getFileLinesCount(cwd, rec.filePath);
-          fileLinesCache.set(rec.filePath, lines);
-        }
-        weight *= fileSizeFactor(lines);
-      }
-      byCategoryHours[cat] += weight;
-      totalHours += weight;
-    }
+    for (const rec of arr) accumulate(cat, rec, state, opts);
   }
 
-  const days = totalHours / 8;
-  const weeks = days / 5;
+  const { hours, days, weeks } = toDurations(state.totalHours);
   return {
-    hours: round1(totalHours),
-    days: round1(days),
-    weeks: round1(weeks),
+    hours, days, weeks,
     byCategory: {
-      magicNumbers: round1(byCategoryHours.magicNumbers),
-      domainTerms: round1(byCategoryHours.domainTerms),
-      architecture: round1(byCategoryHours.architecture),
-      complexity: round1(byCategoryHours.complexity)
+      magicNumbers: round1(state.byCategoryHours.magicNumbers),
+      domainTerms: round1(state.byCategoryHours.domainTerms),
+      architecture: round1(state.byCategoryHours.architecture),
+      complexity: round1(state.byCategoryHours.complexity)
     }
   };
 }


### PR DESCRIPTION
Phase 3A: Reduce estimator complexity by extracting helpers; behavior unchanged.

Changes
- Added helpers:
  - computeBaseWeight(ruleId)
  - getCachedLines(cwd, filePath, cache)
  - weightForRecord(rec, opts, cache)
  - accumulate(cat, rec, state, opts)
  - toDurations(totalHours)
- estimateEffort now orchestrates using helpers; same JSON shape and numbers.

Verification
- Tests: 599 passing, 3 pending.
- Ratchet: OK (no increases).
- Analyzer: estimator function complexity reduced (targeting ≤10).

Notes
- Kept all logic within the same file to minimize risk; no external API changes.
