### PR TITLE
refactor(analyze): reduce analyzeCommand complexity (Phase 3A)

### DIFF
--- a/lib/commands/analyze/index.js
+++ b/lib/commands/analyze/index.js
@@ -10,38 +10,73 @@ const { attachDomainContext } = require('./domain');
 
 function numArg(v, d) { const n = Number(v); return Number.isFinite(n) && n > 0 ? n : d; }
 
+// ===== Extracted helpers to reduce complexity =====
+function resolveInputPath(cwd, args) {
+  const input = args._ && args._[1] ? args._[1] : (args.input || 'lint-results.json');
+  return path.isAbsolute(input) ? input : path.join(cwd, input);
+}
+
+function parseOptions(args) {
+  const outFile = args.output || 'analysis-report.md';
+  const format = (args.format || 'markdown').toLowerCase();
+  const useFileSize = String(args['estimate-size'] ?? args.estimateSize ?? 'false').toLowerCase() === 'true';
+  const topFiles = numArg(args['top-files'] || args.topFiles, 10);
+  const minCount = numArg(args['min-count'] || args.minCount, 1);
+  const maxExamples = numArg(args['max-examples'] || args.maxExamples, 5);
+  return { outFile, format, useFileSize, topFiles, minCount, maxExamples };
+}
+
+function readLintJson(file) {
+  const raw = fs.readFileSync(file, 'utf8');
+  return JSON.parse(raw);
+}
+
+function loadConfig(cwd) {
+  return readProjectConfig({ getFilename: () => path.join(cwd, 'placeholder.js'), getCwd: () => cwd });
+}
+
+function analyze(categories, cfg, cwd, useFileSize) {
+  const effort = estimateEffort(categories, { cwd, useFileSize });
+  return { categories, effort, cfg };
+}
+
+function computeCategories(json, cfg) {
+  let categories = categorizeViolations(json, cfg);
+  categories = attachDomainContext(categories, cfg);
+  return categories;
+}
+
+function escapeHtml(s) {
+  const htmlChars = { '&':'&amp;','<':'&lt;','>':'&gt;' };
+  return s.replace(/[&<>]/g, (ch) => htmlChars[ch]);
+}
+
+function writeOutput(cwd, opts, payload) {
+  const outPath = path.join(cwd, opts.outFile);
+  if (opts.format === 'markdown') {
+    writeAnalysisReport(outPath, { ...payload, topFiles: opts.topFiles, minCount: opts.minCount, maxExamples: opts.maxExamples });
+    return;
+  }
+  if (opts.format === 'json') {
+    fs.writeFileSync(outPath, JSON.stringify({ categories: payload.categories, effort: payload.effort }, null, 2) + '\n');
+    return;
+  }
+  if (opts.format === 'html') {
+    const md = writeAnalysisReport(null, { ...payload, returnString: true });
+    const html = `<!doctype html><meta charset="utf-8"><title>Analysis Report</title><pre>${escapeHtml(md)}</pre>`;
+    fs.writeFileSync(outPath, html);
+  }
+}
+
 function analyzeCommand(cwd, args) {
   try {
-    const input = args._ && args._[1] ? args._[1] : (args.input || 'lint-results.json');
-    const outFile = args.output || 'analysis-report.md';
-    const format = (args.format || 'markdown').toLowerCase();
-
-    const file = path.isAbsolute(input) ? input : path.join(cwd, input);
-    const raw = fs.readFileSync(file, 'utf8');
-    const json = JSON.parse(raw);
-    const cfg = readProjectConfig({ getFilename: () => path.join(cwd, 'placeholder.js'), getCwd: () => cwd });
-    let categories = categorizeViolations(json, cfg);
-    categories = attachDomainContext(categories, cfg);
-
-    const useFileSize = String(args['estimate-size'] ?? args.estimateSize ?? 'false').toLowerCase() === 'true';
-    const effort = estimateEffort(categories, { cwd, useFileSize });
-
-    const topFiles = numArg(args['top-files'] || args.topFiles, 10);
-    const minCount = numArg(args['min-count'] || args.minCount, 1);
-    const maxExamples = numArg(args['max-examples'] || args.maxExamples, 5);
-
-    const outPath = path.join(cwd, outFile);
-    if (format === 'markdown') {
-      writeAnalysisReport(outPath, { categories, effort, cfg, topFiles, minCount, maxExamples });
-    } else if (format === 'json') {
-      fs.writeFileSync(outPath, JSON.stringify({ categories, effort }, null, 2) + '\n');
-    } else if (format === 'html') {
-      const md = writeAnalysisReport(null, { categories, effort, cfg, returnString: true });
-      const htmlChars = { '&':'&amp;','<':'&lt;','>':'&gt;' };
-      const escaped = md.replace(/[&<>]/g, s => htmlChars[s]);
-      const html = `<!doctype html><meta charset="utf-8"><title>Analysis Report</title><pre>${escaped}</pre>`;
-      fs.writeFileSync(outPath, html);
-    }
+    const file = resolveInputPath(cwd, args);
+    const opts = parseOptions(args);
+    const json = readLintJson(file);
+    const cfg = loadConfig(cwd);
+    const categories = computeCategories(json, cfg);
+    const payload = analyze(categories, cfg, cwd, opts.useFileSize);
+    writeOutput(cwd, opts, payload);
     return 0;
   } catch (e) {
     console.error(`analyze failed: ${e && e.message}`);


### PR DESCRIPTION
Phase 3A: Reduce analyzeCommand complexity by extracting small helpers; behavior unchanged.

Changes
- Added helpers: resolveInputPath, parseOptions, readLintJson, loadConfig, computeCategories, analyze, escapeHtml, writeOutput
- analyzeCommand now orchestrates via helpers; JSON/markdown/html outputs unchanged.

Verification
- Tests: 599 passing, 3 pending.
- Ratchet: OK (no increases).
- Analyzer: analyzeCommand complexity reduced (targeting ≤10).

Notes
- Kept helpers in-file to minimize risk. Future Phase 3B may move output builders to subfiles.
