### PR TITLE
refactor(learn): reduce learnCommand complexity (Phase 3A)

### DIFF
--- a/lib/commands/learn/index.js
+++ b/lib/commands/learn/index.js
@@ -185,31 +185,27 @@ async function learnInteractiveCommand(cwd, args, findings, rec, currentCfg) {
   }
 }
 
-function learnCommand(cwd, args) {
-  const { scanProject } = require(path.join(__dirname, '..', '..', 'scanner', 'extract'));
-  const { reconcile, DEFAULT_SANITY } = require(path.join(__dirname, '..', '..', 'scanner', 'reconcile'));
-  const { json: currentCfg } = loadProjectConfigFile(cwd);
-  const modeInteractive = Boolean(args.interactive) || (!args.strict && !args.permissive && process.stdin.isTTY);
-  const sample = args.sample ? Number(args.sample) : undefined;
-  const useCache = !!args.cache || args['no-cache'];
-
-  console.log(`Scanning project (sample: ${sample || 400}, cache: ${useCache ? 'enabled' : 'disabled'})...`);
-  const findings = scanProject(cwd, { sample: sample || 400, useCache });
-  console.log('✓ Scan complete');
-  // Override defaults with CLI flags or config values
+// ===== Helpers to reduce learnCommand complexity =====
+function getSample(args) { return args.sample ? Number(args.sample) : undefined; }
+function isInteractive(args) { return Boolean(args.interactive) || (!args.strict && !args.permissive && process.stdin.isTTY); }
+function getUseCache(args) { return !!args.cache || args['no-cache']; }
+function buildSanity(args, currentCfg, DEFAULT_SANITY) {
   const sane = { ...DEFAULT_SANITY };
   if (args.minimumMatch) sane.minimumMatch = parseFloat(args.minimumMatch);
   else if (currentCfg.minimumMatch !== undefined) sane.minimumMatch = currentCfg.minimumMatch;
   if (args.minimumConfidence) sane.minimumConfidence = parseFloat(args.minimumConfidence);
   else if (currentCfg.minimumConfidence !== undefined) sane.minimumConfidence = currentCfg.minimumConfidence;
-  const mode = args.strict ? 'strict' : (args.permissive ? 'permissive' : 'adaptive');
+  return sane;
+}
+function computeMode(args) { return args.strict ? 'strict' : (args.permissive ? 'permissive' : 'adaptive'); }
+function reconcileResult({ cwd, args, currentCfg, DEFAULT_SANITY, findings }) {
+  const { reconcile } = require(path.join(__dirname, '..', '..', 'scanner', 'reconcile'));
+  const sane = buildSanity(args, currentCfg, DEFAULT_SANITY);
+  const mode = computeMode(args);
   const rec = reconcile(findings, sane, { config: currentCfg, mode });
-
-  if (modeInteractive) {
-    return learnInteractiveCommand(cwd, args, findings, rec, currentCfg);
-  }
-
-  // Non-interactive: compute result and optionally apply
+  return { rec, mode };
+}
+function nonInteractiveApply({ cwd, args, currentCfg, rec, mode }) {
   const nextCfg = deepMerge(currentCfg, { naming: rec.result.naming, antiPatterns: rec.result.antiPatterns, constantResolution: rec.result.constantResolution });
   if (args.apply) {
     if (mode === 'permissive') {
@@ -224,18 +220,37 @@ function learnCommand(cwd, args) {
   } else {
     console.log(JSON.stringify({ mode, score: rec.score, result: rec.result, warnings: rec.warnings, domain: rec.domain.summary }, null, 2));
   }
-  if (args.fingerprint) {
-    const top = (rec.domain && rec.domain.constants || []).slice(0, 10);
-    if (top.length) {
-      const { generateDomain } = require(path.join(__dirname, '..', '..', 'scanner', 'reconcile'));
-      const content = generateDomain({ constants: top });
-      const outDir = path.join(cwd, '.ai-constants');
-      fs.mkdirSync(outDir, { recursive: true });
-      const outFile = path.join(outDir, 'project-fingerprint.js');
-      fs.writeFileSync(outFile, content);
-      console.log(`Wrote ${outFile}`);
-    }
-  }
+}
+function maybeWriteFingerprint(cwd, args, rec) {
+  if (!args.fingerprint) return;
+  const top = (rec.domain && rec.domain.constants || []).slice(0, 10);
+  if (!top.length) return;
+  const { generateDomain } = require(path.join(__dirname, '..', '..', 'scanner', 'reconcile'));
+  const content = generateDomain({ constants: top });
+  const outDir = path.join(cwd, '.ai-constants');
+  fs.mkdirSync(outDir, { recursive: true });
+  const outFile = path.join(outDir, 'project-fingerprint.js');
+  fs.writeFileSync(outFile, content);
+  console.log(`Wrote ${outFile}`);
+}
+
+function learnCommand(cwd, args) {
+  const { scanProject } = require(path.join(__dirname, '..', '..', 'scanner', 'extract'));
+  const { DEFAULT_SANITY } = require(path.join(__dirname, '..', '..', 'scanner', 'reconcile'));
+  const { json: currentCfg } = loadProjectConfigFile(cwd);
+  const modeInteractive = isInteractive(args);
+  const sample = getSample(args);
+  const useCache = getUseCache(args);
+
+  console.log(`Scanning project (sample: ${sample || 400}, cache: ${useCache ? 'enabled' : 'disabled'})...`);
+  const findings = scanProject(cwd, { sample: sample || 400, useCache });
+  console.log('✓ Scan complete');
+
+  const { rec, mode } = reconcileResult({ cwd, args, currentCfg, DEFAULT_SANITY, findings });
+  if (modeInteractive) return learnInteractiveCommand(cwd, args, findings, rec, currentCfg);
+
+  nonInteractiveApply({ cwd, args, currentCfg, rec, mode });
+  maybeWriteFingerprint(cwd, args, rec);
   return 0;
 }
 


### PR DESCRIPTION
Phase 3A: Reduce learnCommand (non-interactive) complexity; behavior unchanged.

Changes
- Added helpers: getSample, isInteractive, getUseCache, buildSanity, computeMode, reconcileResult(obj), nonInteractiveApply(obj), maybeWriteFingerprint
- learnCommand now orchestrates using these helpers while preserving outputs and modes.

Verification
- Tests: 599 passing, 3 pending.
- Ratchet: OK (no increases).
- Analyzer: learnCommand complexity reduced (target ≤10).

Notes
- No CLI surface changes; interactive flow remains as-is (already refactored).
