### PR TITLE
refactor(utils): lower complexity in discover-constants (Phase 3A)

### DIFF
--- a/lib/utils/discover-constants.js
+++ b/lib/utils/discover-constants.js
@@ -21,64 +21,80 @@ function loadBuiltinConstants() {
     }
   } catch (err) {
     if (process.env.DEBUG_AI_CONSTANTS) {
-       
       console.warn(`[discover-constants] failed to read builtin constants: ${err && err.message}`);
     }
   }
   return out;
 }
 
+// ===== Helpers to reduce discoverNpmPackages complexity =====
+function computeCacheKey(projectRoot, pkg) {
+  const depsString = JSON.stringify({ d: pkg.dependencies || {}, dv: pkg.devDependencies || {} });
+  return projectRoot + ':' + sha1(depsString);
+}
+
+function isAllowedPackage(name, allowlist, patterns) {
+  if (!patterns.some((p) => p.test(name))) return false;
+  if (Array.isArray(allowlist) && allowlist.length) {
+    for (const rule of allowlist) {
+      if (!rule) continue;
+      if (rule.startsWith('^')) {
+        try { if (new RegExp(rule).test(name)) return true; } catch { /* ignore */ }
+      } else if (rule === name) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return true;
+}
+
+function safeSetCache(key, value) {
+  try { CACHE.npm.set(key, value); } catch (e) {
+    if (process.env.DEBUG_AI_CONSTANTS) console.warn(`[discover-constants] cache set failed: ${e && e.message}`);
+  }
+}
+
+function safeGetCache(key) {
+  try { return CACHE.npm.get(key); } catch { return undefined; }
+}
+
+function loadNpmPackage(name) {
+  try {
+    const mod = require(name);
+    const packageMeta = mod && (mod.default || mod);
+    validateConstantsPackage(packageMeta);
+    return { ok: true, meta: packageMeta };
+  } catch (err) {
+    if (process.env.DEBUG_AI_CONSTANTS) console.warn(`[discover-constants] failed to load ${name}: ${err && err.message}`);
+    return { ok: false };
+  }
+}
+
 function discoverNpmPackages(projectRoot, allowlist) {
-const pkgPath = path.join(projectRoot, 'package.json');
+  const pkgPath = path.join(projectRoot, 'package.json');
   const pkg = readJson(pkgPath) || {};
   const all = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
   const patterns = [/^@ai-constants\//, /^eslint-constants-/, /-ai-constants$/];
   const out = {};
-try {
-    const depsString = JSON.stringify({ d: pkg.dependencies || {}, dv: pkg.devDependencies || {} });
-    const key = projectRoot + ':' + sha1(depsString);
-    if (CACHE.npm.has(key) && !process.env.AI_CONSTANTS_NO_CACHE) {
-      return CACHE.npm.get(key);
-    }
+
+  let key;
+  try {
+    key = computeCacheKey(projectRoot, pkg);
+    if (CACHE.npm.has(key) && !process.env.AI_CONSTANTS_NO_CACHE) return safeGetCache(key);
   } catch (e) {
-    if (process.env.DEBUG_AI_CONSTANTS) {
-       
-      console.warn(`[discover-constants] cache key compute failed: ${e && e.message}`);
-    }
+    if (process.env.DEBUG_AI_CONSTANTS) console.warn(`[discover-constants] cache key compute failed: ${e && e.message}`);
   }
+
   for (const name of Object.keys(all)) {
-if (!patterns.some((p) => p.test(name))) continue;
-    if (Array.isArray(allowlist) && allowlist.length) {
-      const allowed = allowlist.some((rule) => {
-        if (!rule) return false;
-        if (rule.startsWith('^')) { try { return new RegExp(rule).test(name); } catch { return false; } }
-        return rule === name;
-      });
-      if (!allowed) continue;
-    }
-    try {
-      const mod = require(name);
-      const packageMeta = mod && (mod.default || mod);
-      validateConstantsPackage(packageMeta);
-      out[packageMeta.domain] = { ...packageMeta, source: 'npm', package: name };
-    } catch (err) {
-      // skip invalid packages but log in debug
-      if (process.env.DEBUG_AI_CONSTANTS) {
-         
-        console.warn(`[discover-constants] failed to load ${name}: ${err && err.message}`);
-      }
+    if (!isAllowedPackage(name, allowlist, patterns)) continue;
+    const loaded = loadNpmPackage(name);
+    if (loaded.ok) {
+      const meta = loaded.meta;
+      out[meta.domain] = { ...meta, source: 'npm', package: name };
     }
   }
-try {
-    const depsString = JSON.stringify({ d: pkg.dependencies || {}, dv: pkg.devDependencies || {} });
-    const key = projectRoot + ':' + sha1(depsString);
-    CACHE.npm.set(key, out);
-  } catch (e) {
-    if (process.env.DEBUG_AI_CONSTANTS) {
-       
-      console.warn(`[discover-constants] cache set failed: ${e && e.message}`);
-    }
-  }
+  if (key) safeSetCache(key, out);
   return out;
 }
 
@@ -94,10 +110,7 @@ function discoverLocalFiles(projectRoot) {
       validateConstantsPackage(packageMeta);
       out[packageMeta.domain] = { ...packageMeta, source: 'local', file: f };
     } catch (err) {
-      if (process.env.DEBUG_AI_CONSTANTS) {
-         
-        console.warn(`[discover-constants] failed to load ${f}: ${err && err.message}`);
-      }
+      if (process.env.DEBUG_AI_CONSTANTS) console.warn(`[discover-constants] failed to load ${f}: ${err && err.message}`);
     }
   }
   return out;
@@ -115,7 +128,7 @@ function loadCustomConstants(projectRoot) {
 }
 
 function discoverConstants(projectRoot = process.cwd()) {
-const cfg = readJson(path.join(projectRoot, '.ai-coding-guide.json')) || {};
+  const cfg = readJson(path.join(projectRoot, '.ai-coding-guide.json')) || {};
   const allowlist = Array.isArray(cfg.externalConstantsAllowlist) ? cfg.externalConstantsAllowlist : [];
   return {
     builtin: loadBuiltinConstants(),


### PR DESCRIPTION
Phase 3A: Reduce complexity in discover-constants.js while preserving behavior.

Changes
- Extracted helpers:
  - computeCacheKey(projectRoot, pkg)
  - isAllowedPackage(name, allowlist, patterns)
  - safeSetCache(key, value), safeGetCache(key)
  - loadNpmPackage(name)
- discoverNpmPackages now uses helpers to simplify flow and reduce branching.
- Kept builtin/local/custom loaders unchanged (minor log cleanups).

Verification
- Tests: 599 passing, 3 pending.
- Ratchet: OK (no increases).
- Analyzer: discoverNpmPackages complexity reduced (26 → lower).

Notes
- No change to external behavior; caching/env flags honored as before.
