### PR TITLE
ci: enforce health gate (remove continue-on-error; run ratchet:context normally)

### DIFF
--- a/.github/workflows/ci-ratchet.yml
+++ b/.github/workflows/ci-ratchet.yml
@@ -29,17 +29,15 @@ jobs:
         run: npm run analyze:current
 
       - name: Ratchet (fail on new debt)
-        continue-on-error: ${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'feat/health-gating') }}
         run: npm run ratchet
 
-      - name: Context-aware ratchet (telemetry only)
-        continue-on-error: true
+      - name: Health gate (context-aware ratchet)
         run: |
           # Prefer script if available, otherwise fallback to direct invocation
           if npm run -s | grep -q "ratchet:context"; then
-            npm run ratchet:context || true
+            npm run ratchet:context
           else
-            node scripts/ratchet.js --mode=context --baseline=analysis-baseline.json --current=analysis-current.json || true
+            node scripts/ratchet.js --mode=context --baseline=analysis-baseline.json --current=analysis-current.json
           fi
 
       - name: Run tests


### PR DESCRIPTION
Summary
- Remove continue-on-error from health telemetry step
- Run ratchet:context normally (no `|| true`) so gating can actually fail when enabled
- Keep job name `ratchet-and-tests` stable for branch protection

Behavior
- With health.enabled=false (default), step exits 0 and job passes
- With health.enabled=true and score below thresholds, step exits non-zero and job fails

Next (branch protection)
- Set `ratchet-and-tests` as a required check for `main`
- Optionally also require `CI / Test on Node.js 20.x`

Refs
- #203 Health Gating Enforcement
- #208 health gating foundations
- #212 ratchet DX improvements